### PR TITLE
Fixed a bug in shared string table reading

### DIFF
--- a/ZA2X/CLAS/ZCL_EXCEL_READER_HUGE_FILE.slnk
+++ b/ZA2X/CLAS/ZCL_EXCEL_READER_HUGE_FILE.slnk
@@ -1,21 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<CLAS CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" VERSION="1" LANGU="E" DESCRIPT="Can read large .xlsx files" CATEGORY="00" EXPOSURE="2" STATE="1" RELEASE="0" CLSCCINCL="X" FIXPT="X" UNICODE="X" CLSBCCAT="00" WITH_UNIT_TESTS="X" DURATION_TYPE="0 " RISK_LEVEL="0 " REFCLSNAME="ZCL_EXCEL_READER_2007">
- <types CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="T_CELL_CONTENT" VERSION="1" LANGU="E" EXPOSURE="0" STATE="1" EDITORDER="1 " TYPTYPE="4" SRCROW1="4 " SRCCOLUMN1="4 " SRCROW2="9 " SRCCOLUMN2="24 " TYPESRC_LENG="219 " TYPESRC="begin of t_cell_content,
-      datatype type zexcel_cell_data_type,
-      value    type zexcel_cell_value,
-      formula  type zexcel_cell_formula,
-      style    type zexcel_cell_style,
-    end of t_cell_content
+<CLAS CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" VERSION="1" LANGU="D" DESCRIPT="Can read large .xlsx files" CATEGORY="00" EXPOSURE="2" STATE="1" RELEASE="0" CLSCCINCL="X" FIXPT="X" UNICODE="X" CLSBCCAT="00" WITH_UNIT_TESTS="X" DURATION_TYPE="0 " RISK_LEVEL="0 " REFCLSNAME="ZCL_EXCEL_READER_2007">
+ <types CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="T_CELL_CONTENT" VERSION="1" LANGU="D" EXPOSURE="0" STATE="1" EDITORDER="1 " TYPTYPE="4" SRCROW1="4 " SRCCOLUMN1="4 " SRCROW2="9 " SRCCOLUMN2="24 " TYPESRC_LENG="219 " TYPESRC="begin of t_cell_content,
+
+      datatype type zexcel_cell_data_type,
+
+      value    type zexcel_cell_value,
+
+      formula  type zexcel_cell_formula,
+
+      style    type zexcel_cell_style,
+
+    end of t_cell_content
+
 "/>
- <types CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="T_CELL_COORD" VERSION="1" LANGU="E" EXPOSURE="0" STATE="1" EDITORDER="2 " TYPTYPE="4" SRCROW1="11 " SRCCOLUMN1="4 " SRCROW2="14 " SRCCOLUMN2="22 " TYPESRC_LENG="134 " TYPESRC="begin of t_cell_coord,
-      row      type zexcel_cell_row,
-      column   type zexcel_cell_column_alpha,
-    end of t_cell_coord
+ <types CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="T_CELL_COORD" VERSION="1" LANGU="D" EXPOSURE="0" STATE="1" EDITORDER="2 " TYPTYPE="4" SRCROW1="11 " SRCCOLUMN1="4 " SRCROW2="14 " SRCCOLUMN2="22 " TYPESRC_LENG="134 " TYPESRC="begin of t_cell_coord,
+
+      row      type zexcel_cell_row,
+
+      column   type zexcel_cell_column_alpha,
+
+    end of t_cell_coord
+
 "/>
- <types CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="T_CELL" VERSION="1" LANGU="E" EXPOSURE="0" STATE="1" EDITORDER="3 " TYPTYPE="4" SRCROW1="16 " SRCCOLUMN1="4 " SRCROW2="19 " SRCCOLUMN2="21 " TYPESRC_LENG="140 " TYPESRC="begin of t_cell.
-          include type t_cell_coord as coord.
-          include type t_cell_content as content.
-  types: end of t_cell
+ <types CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="T_CELL" VERSION="1" LANGU="D" EXPOSURE="0" STATE="1" EDITORDER="3 " TYPTYPE="4" SRCROW1="16 " SRCCOLUMN1="4 " SRCROW2="19 " SRCCOLUMN2="21 " TYPESRC_LENG="140 " TYPESRC="begin of t_cell.
+
+          include type t_cell_coord as coord.
+
+          include type t_cell_content as content.
+
+  types: end of t_cell
+
 "/>
  <localImplementation>*&quot;* use this source file for the definition and implementation of
 *&quot;* local helper classes, interface definitions and type
@@ -26,11 +40,11 @@ class lcx_not_found implementation.
   method constructor.
     super-&gt;constructor( textid = textid previous = previous ).
     me-&gt;error = error.
-  endmethod.
+  endmethod.                    &quot;constructor
   method if_message~get_text.
     result = error.
-  endmethod.
-endclass.</localImplementation>
+  endmethod.                    &quot;if_message~get_text
+endclass.                    &quot;lcx_not_found IMPLEMENTATION</localImplementation>
  <localTypes>*&quot;* use this source file for any type of declarations (class
 *&quot;* definitions, interfaces or type declarations) you need for
 *&quot;* components in the private section
@@ -48,123 +62,150 @@ endclass.</localTypes>
  <localMacros>*&quot;* use this source file for any macro definitions you need
 *&quot;* in the implementation part of the class</localMacros>
  <localTestClasses>*&quot;* use this source file for your ABAP unit test classes
-CLASS lcl_test DEFINITION DEFERRED.
-CLASS zcl_excel_reader_huge_file DEFINITION LOCAL FRIENDS lcl_test.
+class lcl_test definition deferred.
+class zcl_excel_reader_huge_file definition local friends lcl_test.
 
 *
-CLASS lcl_test DEFINITION FOR TESTING  &quot; #AU Risk_Level Harmless
-      INHERITING FROM cl_aunit_assert. &quot; #AU Duration Short
+class lcl_test definition for testing  &quot; #AU Risk_Level Harmless
+      inheriting from cl_aunit_assert. &quot; #AU Duration Short
 
-  PRIVATE SECTION.
-    DATA:
-      out TYPE REF TO zcl_excel_reader_huge_file, &quot; object under test
-      excel TYPE REF TO zcl_excel,
-      worksheet TYPE REF TO zcl_excel_worksheet.
-    METHODS:
+  private section.
+    data:
+      out type ref to zcl_excel_reader_huge_file, &quot; object under test
+      excel type ref to zcl_excel,
+      worksheet type ref to zcl_excel_worksheet.
+    methods:
       setup,
-      test_number FOR TESTING,
-      test_shared_string FOR TESTING,
-      test_shared_string_missing FOR TESTING,
-      test_inline_string FOR TESTING,
-      test_boolean FOR TESTING,
-      test_style FOR TESTING,
-      test_style_missing FOR TESTING,
-      test_formula FOR TESTING,
-      test_read_shared_strings FOR TESTING,
-      test_skip_to_inexistent FOR TESTING,
-      get_reader IMPORTING iv_xml TYPE string RETURNING VALUE(eo_reader) TYPE REF TO if_sxml_reader,
-      assert_value_equals IMPORTING iv_row TYPE i DEFAULT 1 iv_col TYPE i DEFAULT 1 iv_value TYPE string,
-      assert_formula_equals IMPORTING iv_row TYPE i DEFAULT 1 iv_col TYPE i DEFAULT 1 iv_formula TYPE string,
-      assert_style_equals IMPORTING iv_row TYPE i DEFAULT 1 iv_col TYPE i DEFAULT 1 iv_style TYPE zexcel_cell_style,
-      assert_datatype_equals IMPORTING iv_row TYPE i DEFAULT 1 iv_col TYPE i DEFAULT 1 iv_datatype TYPE string.
+      test_number for testing,
+      test_shared_string for testing,
+      test_shared_string_missing for testing,
+      test_inline_string for testing,
+      test_empty_cells for testing,
+      test_boolean for testing,
+      test_style for testing,
+      test_style_missing for testing,
+      test_formula for testing,
+      test_read_shared_strings for testing,
+      test_skip_to_inexistent for testing,
+      get_reader importing iv_xml type string returning value(eo_reader) type ref to if_sxml_reader,
+      assert_value_equals importing iv_row type i default 1 iv_col type i default 1 iv_value type string,
+      assert_formula_equals importing iv_row type i default 1 iv_col type i default 1 iv_formula type string,
+      assert_style_equals importing iv_row type i default 1 iv_col type i default 1 iv_style type ZEXCEL_CELL_STYLE,
+      assert_datatype_equals importing iv_row type i default 1 iv_col type i default 1 iv_datatype type string.
 
-ENDCLASS.                    &quot;lcl_test DEFINITION
-
-*
-CLASS lcl_test IMPLEMENTATION.
+endclass.                    &quot;lcl_test DEFINITION
 
 *
-  METHOD test_number.
-    DATA lo_reader TYPE REF TO if_sxml_reader.
+class lcl_test implementation.
+
+*
+  method test_number.
+    data lo_reader type ref to if_sxml_reader.
     lo_reader = get_reader(
       `&lt;c r=&quot;A1&quot; t=&quot;n&quot;&gt;&lt;v&gt;17&lt;/v&gt;&lt;/c&gt;`
       ).
     out-&gt;read_worksheet_data( io_reader = lo_reader io_worksheet = worksheet ).
     assert_value_equals( `17` ).
     assert_datatype_equals( `n` ).
-  ENDMETHOD.                    &quot;test_shared_string
+  endmethod.                    &quot;test_shared_string
 
 *
-  METHOD test_shared_string.
-    DATA lo_reader TYPE REF TO if_sxml_reader.
-    APPEND `Test` TO out-&gt;shared_strings.
+  method test_shared_string.
+    data lo_reader type ref to if_sxml_reader.
+    append `Test1` to out-&gt;shared_strings.
+    append `Test2` to out-&gt;shared_strings.
     lo_reader = get_reader(
-      `&lt;c r=&quot;A1&quot; t=&quot;s&quot;&gt;&lt;v&gt;0&lt;/v&gt;&lt;/c&gt;`
+      `&lt;c r=&quot;A1&quot; t=&quot;s&quot;&gt;&lt;v&gt;1&lt;/v&gt;&lt;/c&gt;`
       ).
     out-&gt;read_worksheet_data( io_reader = lo_reader io_worksheet = worksheet ).
-    assert_value_equals( `Test` ).
+    assert_value_equals( `Test2` ).
     assert_datatype_equals( `s` ).
-  ENDMETHOD.                    &quot;test_shared_string
+  endmethod.                    &quot;test_shared_string
 *
-  METHOD test_shared_string_missing.
+  method test_shared_string_missing.
 
-    DATA: lo_reader TYPE REF TO if_sxml_reader,
-          lo_ex TYPE REF TO lcx_not_found,
-          lv_text TYPE string.
+    data: lo_reader type ref to if_sxml_reader,
+          lo_ex type ref to lcx_not_found,
+          lv_text type string.
+    append `Test` to out-&gt;shared_strings.
     lo_reader = get_reader(
-      `&lt;c r=&quot;A1&quot; t=&quot;s&quot;&gt;&lt;v&gt;0&lt;/v&gt;&lt;/c&gt;`
+      `&lt;c r=&quot;A1&quot; t=&quot;s&quot;&gt;&lt;v&gt;1&lt;/v&gt;&lt;/c&gt;`
       ).
 
-    TRY.
+    try.
         out-&gt;read_worksheet_data( io_reader = lo_reader io_worksheet = worksheet ).
         fail(`Index to non-existent shared string should give an error`).
-      CATCH lcx_not_found INTO lo_ex.
+      catch lcx_not_found into lo_ex.
         lv_text = lo_ex-&gt;get_text( ). &quot; &gt;&gt;&gt; May inspect the message in the debugger
-    ENDTRY.
+    endtry.
 
-  ENDMETHOD.
+  endmethod.
 *
-  METHOD test_inline_string.
-    DATA lo_reader TYPE REF TO if_sxml_reader.
+  method test_inline_string.
+    data lo_reader type ref to if_sxml_reader.
     lo_reader = get_reader(
       `&lt;c r=&quot;A1&quot; t=&quot;inlineStr&quot;&gt;&lt;is&gt;&lt;t&gt;Alpha&lt;/t&gt;&lt;/is&gt;&lt;/c&gt;`
       ).
     out-&gt;read_worksheet_data( io_reader = lo_reader io_worksheet = worksheet ).
     assert_value_equals( `Alpha` ).
     assert_datatype_equals( `inlineStr` ).
-  ENDMETHOD.                    &quot;test_inline_string
+  endmethod.                    &quot;test_inline_string
 
 *
-  METHOD test_boolean.
-    DATA lo_reader TYPE REF TO if_sxml_reader.
+  method test_boolean.
+    data lo_reader type ref to if_sxml_reader.
     lo_reader = get_reader(
       `&lt;c r=&quot;A1&quot; t=&quot;b&quot;&gt;&lt;v&gt;1&lt;/v&gt;&lt;/c&gt;`
       ).
     out-&gt;read_worksheet_data( io_reader = lo_reader io_worksheet = worksheet ).
     assert_value_equals( `1` ).
     assert_datatype_equals( `b` ).
-  ENDMETHOD.                    &quot;test_boolean
+  endmethod.                    &quot;test_boolean
 
 *
-  METHOD test_formula.
-    DATA lo_reader TYPE REF TO if_sxml_reader.
+  method test_formula.
+    data lo_reader type ref to if_sxml_reader.
     lo_reader = get_reader(
       `&lt;c r=&quot;A1&quot; t=&quot;n&quot;&gt;&lt;f&gt;A2*A2&lt;/f&gt;&lt;/c&gt;`
       ).
     out-&gt;read_worksheet_data( io_reader = lo_reader io_worksheet = worksheet ).
     assert_formula_equals( `A2*A2` ).
     assert_datatype_equals( `n` ).
-  ENDMETHOD.                    &quot;test_formula
+  endmethod.                    &quot;test_formula
 
 *
-  METHOD test_style.
-    DATA:
-      lo_reader TYPE REF TO if_sxml_reader,
-      lo_style  TYPE REF TO zcl_excel_style,
-      lv_guid TYPE zexcel_cell_style.
-    CREATE OBJECT lo_style.
-    APPEND lo_style TO out-&gt;styles.
-    lv_guid = lo_style-&gt;get_guid( ).
+  method test_empty_cells.
+
+* There is no need to store an empty cell in the ABAP worksheet structure
+
+    data: lo_reader type ref to if_sxml_reader,
+          lo_ex type ref to lcx_not_found,
+          lv_text type string.
+    append `` to out-&gt;shared_strings.
+    append `t` to out-&gt;shared_strings.
+    lo_reader = get_reader(
+      `&lt;c r=&quot;A1&quot; t=&quot;s&quot;&gt;&lt;v&gt;0&lt;/v&gt;&lt;/c&gt;` &amp;&amp;
+      `&lt;c r=&quot;A2&quot; t=&quot;inlineStr&quot;&gt;&lt;is&gt;&lt;t&gt;&lt;/t&gt;&lt;/is&gt;&lt;/c&gt;` &amp;&amp;
+      `&lt;c r=&quot;A3&quot; t=&quot;s&quot;&gt;&lt;v&gt;1&lt;/v&gt;&lt;/c&gt;`
+      ).
+
+    out-&gt;read_worksheet_data( io_reader = lo_reader io_worksheet = worksheet ).
+
+    assert_value_equals( iv_row = 1 iv_col = 1 iv_value = `` ).
+    assert_value_equals( iv_row = 2 iv_col = 1 iv_value = `` ).
+    assert_value_equals( iv_row = 3 iv_col = 1 iv_value = `t` ).
+
+  endmethod.
+
+*
+  method test_style.
+    data:
+      lo_reader type ref to if_sxml_reader,
+      lo_style  type ref to zcl_excel_style,
+      lv_guid type ZEXCEL_CELL_STYLE.
+      create object lo_style.
+      append lo_style to out-&gt;styles.
+      lv_guid = lo_style-&gt;get_guid( ).
 
     lo_reader = get_reader(
       `&lt;c r=&quot;A1&quot; s=&quot;0&quot;&gt;&lt;v&gt;18&lt;/v&gt;&lt;/c&gt;`
@@ -173,150 +214,162 @@ CLASS lcl_test IMPLEMENTATION.
 
     assert_style_equals( lv_guid ).
 
-  ENDMETHOD.                    &quot;test_style
+  endmethod.                    &quot;test_style
 
 *
-  METHOD test_style_missing.
+  method test_style_missing.
 
-    DATA:
-      lo_reader TYPE REF TO if_sxml_reader,
-      lo_ex TYPE REF TO lcx_not_found,
-      lv_text TYPE string.
+    data:
+      lo_reader type ref to if_sxml_reader,
+      lo_ex type ref to lcx_not_found,
+      lv_text type string.
 
     lo_reader = get_reader(
       `&lt;c r=&quot;A1&quot; s=&quot;0&quot;&gt;&lt;v&gt;18&lt;/v&gt;&lt;/c&gt;`
       ).
 
-    TRY.
+    try.
         out-&gt;read_worksheet_data( io_reader = lo_reader io_worksheet = worksheet ).
         fail(`Reference to non-existent style should throw an lcx_not_found exception`).
-      CATCH lcx_not_found INTO lo_ex.
+      catch lcx_not_found into lo_ex.
         lv_text = lo_ex-&gt;get_text( ).  &quot; &gt;&gt;&gt; May inspect the message in the debugger
-    ENDTRY.
+    endtry.
 
-  ENDMETHOD.                    &quot;test_style
+  endmethod.                    &quot;test_style
 
 *
-  METHOD test_read_shared_strings.
-    DATA: lo_reader TYPE REF TO if_sxml_reader,
-          lt_act TYPE stringtab,
-          lt_exp TYPE stringtab.
+  method test_read_shared_strings.
+    data: lo_reader type ref to if_sxml_reader,
+          lt_act type stringtab,
+          lt_exp type stringtab.
     lo_reader = cl_sxml_string_reader=&gt;create( cl_abap_codepage=&gt;convert_to(
       `&lt;sst&gt;&lt;si&gt;&lt;t/&gt;&lt;/si&gt;&lt;si&gt;&lt;t&gt;Alpha&lt;/t&gt;&lt;/si&gt;&lt;si&gt;&lt;t&gt;Bravo&lt;/t&gt;&lt;/si&gt;&lt;/sst&gt;`
       ) ).
-    APPEND :
-     `` TO lt_exp,
-     `Alpha` TO lt_exp,
-     `Bravo` TO lt_exp.
+    append :
+     `` to lt_exp,
+     `Alpha` to lt_exp,
+     `Bravo` to lt_exp.
 
     lt_act = out-&gt;read_shared_strings( lo_reader ).
 
     assert_equals( act = lt_act
                    exp = lt_exp ).
 
-  ENDMETHOD.
+  endmethod.
 
 *
-  METHOD test_skip_to_inexistent.
-    DATA: lo_reader TYPE REF TO if_sxml_reader,
-          lo_ex TYPE REF TO lcx_not_found,
-          lv_text TYPE string.
+  method test_skip_to_inexistent.
+    data: lo_reader type ref to if_sxml_reader,
+          lo_ex type ref to lcx_not_found,
+          lv_text type string.
 
     lo_reader = cl_sxml_string_reader=&gt;create( cl_abap_codepage=&gt;convert_to(
       `&lt;sst&gt;&lt;si&gt;&lt;t/&gt;&lt;/si&gt;&lt;si&gt;&lt;t&gt;Alpha&lt;/t&gt;&lt;/si&gt;&lt;si&gt;&lt;t&gt;Bravo&lt;/t&gt;&lt;/si&gt;&lt;/sst&gt;`
       ) ).
-    TRY.
+    try.
         out-&gt;skip_to( iv_element_name = `nonExistingElement` io_reader = lo_reader ).
         fail(`Skipping to non-existing element must raise lcx_not_found exception`).
-      CATCH lcx_not_found INTO lo_ex.
+      catch lcx_not_found into lo_ex.
         lv_text = lo_ex-&gt;get_text( ). &quot; May inspect exception text in debugger
-    ENDTRY.
-  ENDMETHOD.
+    endtry.
+  endmethod.
 
 *
-  METHOD get_reader.
-    DATA: lv_full TYPE string.
-    CONCATENATE `&lt;root&gt;&lt;sheetData&gt;&lt;row&gt;` iv_xml `&lt;/row&gt;&lt;/sheetData&gt;&lt;/root&gt;` INTO lv_full.
+  method get_reader.
+    data: lv_full type string.
+    concatenate `&lt;root&gt;&lt;sheetData&gt;&lt;row&gt;` iv_xml `&lt;/row&gt;&lt;/sheetData&gt;&lt;/root&gt;` into lv_full.
     eo_reader = cl_sxml_string_reader=&gt;create( cl_abap_codepage=&gt;convert_to( lv_full ) ).
-  ENDMETHOD.                    &quot;get_reader
+  endmethod.                    &quot;get_reader
 *
-  METHOD assert_value_equals.
+  method assert_value_equals.
 
-    FIELD-SYMBOLS: &lt;ls_cell_data&gt; TYPE zexcel_s_cell_data.
+    constants: lc_empty_string type string value is initial.
 
-    READ TABLE worksheet-&gt;sheet_content ASSIGNING &lt;ls_cell_data&gt;
-      WITH TABLE KEY cell_row = iv_row cell_column = iv_col.
-    assert_subrc( sy-subrc ).
+    field-symbols: &lt;ls_cell_data&gt; type zexcel_s_cell_data,
+                   &lt;lv_value&gt; type string.
 
-    assert_equals( act = &lt;ls_cell_data&gt;-cell_value
+    read table worksheet-&gt;sheet_content assigning &lt;ls_cell_data&gt;
+      with table key cell_row = iv_row cell_column = iv_col.
+    if sy-subrc eq 0.
+      assign &lt;ls_cell_data&gt;-cell_value to &lt;lv_value&gt;.
+    else.
+      assign lc_empty_string to &lt;lv_value&gt;.
+    endif.
+
+    assert_equals( act = &lt;lv_value&gt;
                    exp = iv_value ).
 
-  ENDMETHOD.                    &quot;assert_value_equals
+  endmethod.                    &quot;assert_value_equals
 **
-  METHOD assert_formula_equals.
+  method assert_formula_equals.
 
-    FIELD-SYMBOLS: &lt;ls_cell_data&gt; TYPE zexcel_s_cell_data.
+    field-symbols: &lt;ls_cell_data&gt; type zexcel_s_cell_data.
 
-    READ TABLE worksheet-&gt;sheet_content ASSIGNING &lt;ls_cell_data&gt;
-      WITH TABLE KEY cell_row = iv_row cell_column = iv_col.
+    read table worksheet-&gt;sheet_content assigning &lt;ls_cell_data&gt;
+      with table key cell_row = iv_row cell_column = iv_col.
     assert_subrc( sy-subrc ).
 
     assert_equals( act = &lt;ls_cell_data&gt;-cell_formula
                    exp = iv_formula ).
 
-  ENDMETHOD.                    &quot;assert_formula_equals
+  endmethod.                    &quot;assert_formula_equals
 *
-  METHOD assert_style_equals.
+  method assert_style_equals.
 
-    FIELD-SYMBOLS: &lt;ls_cell_data&gt; TYPE zexcel_s_cell_data.
+    field-symbols: &lt;ls_cell_data&gt; type zexcel_s_cell_data.
 
-    READ TABLE worksheet-&gt;sheet_content ASSIGNING &lt;ls_cell_data&gt;
-      WITH TABLE KEY cell_row = iv_row cell_column = iv_col.
+    read table worksheet-&gt;sheet_content assigning &lt;ls_cell_data&gt;
+      with table key cell_row = iv_row cell_column = iv_col.
     assert_subrc( sy-subrc ).
 
     assert_equals( act = &lt;ls_cell_data&gt;-cell_style
                    exp = iv_style ).
 
-  ENDMETHOD.
+  endmethod.
 *
-  METHOD assert_datatype_equals.
+  method assert_datatype_equals.
 
-    FIELD-SYMBOLS: &lt;ls_cell_data&gt; TYPE zexcel_s_cell_data.
+    field-symbols: &lt;ls_cell_data&gt; type zexcel_s_cell_data.
 
-    READ TABLE worksheet-&gt;sheet_content ASSIGNING &lt;ls_cell_data&gt;
-      WITH TABLE KEY cell_row = iv_row cell_column = iv_col.
+    read table worksheet-&gt;sheet_content assigning &lt;ls_cell_data&gt;
+      with table key cell_row = iv_row cell_column = iv_col.
     assert_subrc( sy-subrc ).
 
     assert_equals( act = &lt;ls_cell_data&gt;-data_type
                    exp = iv_datatype ).
 
-  ENDMETHOD.                    &quot;assert_datatype_equals
-  METHOD setup.
-    CREATE OBJECT out.
-    CREATE OBJECT excel.
-    CREATE OBJECT worksheet
-      EXPORTING
+  endmethod.                    &quot;assert_datatype_equals
+  method setup.
+    create object out.
+    create object excel.
+    create object worksheet
+      exporting
         ip_excel = excel.
-  ENDMETHOD.                    &quot;setup
-ENDCLASS.                    &quot;lcl_test IMPLEMENTATION</localTestClasses>
+  endmethod.                    &quot;setup
+endclass.                    &quot;lcl_test IMPLEMENTATION</localTestClasses>
  <typeIntfDef CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" TYPEGROUP="IF_SXML_NODE" VERSION="1" TPUTYPE="2" IMPLICIT="X"/>
- <attribute CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="C_ATTRIBUTE" VERSION="1" LANGU="E" EXPOSURE="0" STATE="1" EDITORDER="5 " ATTDECLTYP="2" ATTVALUE="IF_SXML_NODE=&gt;CO_NT_ATTRIBUTE" ATTEXPVIRT="0" TYPTYPE="1" TYPE="IF_SXML_NODE=&gt;NODE_TYPE" SRCROW1="0 " SRCCOLUMN1="0 " SRCROW2="0 " SRCCOLUMN2="0 " TYPESRC_LENG="0 "/>
- <attribute CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="C_ELEMENT_CLOSE" VERSION="1" LANGU="E" EXPOSURE="0" STATE="1" EDITORDER="3 " ATTDECLTYP="2" ATTVALUE="IF_SXML_NODE=&gt;CO_NT_ELEMENT_CLOSE" ATTEXPVIRT="0" TYPTYPE="1" TYPE="IF_SXML_NODE=&gt;NODE_TYPE" SRCROW1="0 " SRCCOLUMN1="0 " SRCROW2="0 " SRCCOLUMN2="0 " TYPESRC_LENG="0 "/>
- <attribute CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="C_ELEMENT_OPEN" VERSION="1" LANGU="E" EXPOSURE="0" STATE="1" EDITORDER="2 " ATTDECLTYP="2" ATTVALUE="IF_SXML_NODE=&gt;CO_NT_ELEMENT_OPEN" ATTEXPVIRT="0" TYPTYPE="1" TYPE="IF_SXML_NODE=&gt;NODE_TYPE" SRCROW1="0 " SRCCOLUMN1="0 " SRCROW2="0 " SRCCOLUMN2="0 " TYPESRC_LENG="0 "/>
- <attribute CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="C_END_OF_STREAM" VERSION="1" LANGU="E" EXPOSURE="0" STATE="1" EDITORDER="1 " ATTDECLTYP="2" ATTVALUE="IF_SXML_NODE=&gt;CO_NT_FINAL" ATTEXPVIRT="0" TYPTYPE="1" TYPE="IF_SXML_NODE=&gt;NODE_TYPE" SRCROW1="0 " SRCCOLUMN1="0 " SRCROW2="0 " SRCCOLUMN2="0 " TYPESRC_LENG="0 "/>
- <attribute CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GS_BUFFER_STYLE" VERSION="1" LANGU="E" EXPOSURE="0" STATE="1" EDITORDER="4 " ATTDECLTYP="0" ATTEXPVIRT="0" TYPTYPE="4" SRCROW1="26 " SRCCOLUMN1="4 " SRCROW2="29 " SRCCOLUMN2="25 " TYPESRC_LENG="117 " TYPESRC="begin of gs_buffer_style,
-    index type i value -1,
-    guid type zexcel_cell_style,
-    end of gs_buffer_style
+ <attribute CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="C_ATTRIBUTE" VERSION="1" LANGU="D" EXPOSURE="0" STATE="1" EDITORDER="5 " ATTDECLTYP="2" ATTVALUE="IF_SXML_NODE=&gt;CO_NT_ATTRIBUTE" ATTEXPVIRT="0" TYPTYPE="1" TYPE="IF_SXML_NODE=&gt;NODE_TYPE" SRCROW1="0 " SRCCOLUMN1="0 " SRCROW2="0 " SRCCOLUMN2="0 " TYPESRC_LENG="0 "/>
+ <attribute CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="C_ELEMENT_CLOSE" VERSION="1" LANGU="D" EXPOSURE="0" STATE="1" EDITORDER="3 " ATTDECLTYP="2" ATTVALUE="IF_SXML_NODE=&gt;CO_NT_ELEMENT_CLOSE" ATTEXPVIRT="0" TYPTYPE="1" TYPE="IF_SXML_NODE=&gt;NODE_TYPE" SRCROW1="0 " SRCCOLUMN1="0 " SRCROW2="0 " SRCCOLUMN2="0 " TYPESRC_LENG="0 "/>
+ <attribute CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="C_ELEMENT_OPEN" VERSION="1" LANGU="D" EXPOSURE="0" STATE="1" EDITORDER="2 " ATTDECLTYP="2" ATTVALUE="IF_SXML_NODE=&gt;CO_NT_ELEMENT_OPEN" ATTEXPVIRT="0" TYPTYPE="1" TYPE="IF_SXML_NODE=&gt;NODE_TYPE" SRCROW1="0 " SRCCOLUMN1="0 " SRCROW2="0 " SRCCOLUMN2="0 " TYPESRC_LENG="0 "/>
+ <attribute CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="C_END_OF_STREAM" VERSION="1" LANGU="D" EXPOSURE="0" STATE="1" EDITORDER="1 " ATTDECLTYP="2" ATTVALUE="IF_SXML_NODE=&gt;CO_NT_FINAL" ATTEXPVIRT="0" TYPTYPE="1" TYPE="IF_SXML_NODE=&gt;NODE_TYPE" SRCROW1="0 " SRCCOLUMN1="0 " SRCROW2="0 " SRCCOLUMN2="0 " TYPESRC_LENG="0 "/>
+ <attribute CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="C_NODE_VALUE" VERSION="1" LANGU="D" EXPOSURE="0" STATE="1" EDITORDER="6 " ATTDECLTYP="2" ATTVALUE="IF_SXML_NODE=&gt;CO_NT_VALUE" ATTEXPVIRT="0" TYPTYPE="1" TYPE="IF_SXML_NODE=&gt;NODE_TYPE" SRCROW1="0 " SRCCOLUMN1="0 " SRCROW2="0 " SRCCOLUMN2="0 " TYPESRC_LENG="0 "/>
+ <attribute CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GS_BUFFER_STYLE" VERSION="1" LANGU="D" EXPOSURE="0" STATE="1" EDITORDER="4 " ATTDECLTYP="0" ATTEXPVIRT="0" TYPTYPE="4" SRCROW1="26 " SRCCOLUMN1="4 " SRCROW2="29 " SRCCOLUMN2="25 " TYPESRC_LENG="117 " TYPESRC="begin of gs_buffer_style,
+
+    index type i value -1,
+
+    guid type zexcel_cell_style,
+
+    end of gs_buffer_style
+
 "/>
  <inheritance CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" REFCLSNAME="ZCL_EXCEL_READER_2007" VERSION="1" STATE="1">
   <redefinition CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" REFCLSNAME="ZCL_EXCEL_READER_2007" VERSION="1" MTDNAME="LOAD_SHARED_STRINGS" EXPOSURE="1"/>
   <redefinition CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" REFCLSNAME="ZCL_EXCEL_READER_2007" VERSION="1" MTDNAME="LOAD_WORKSHEET" EXPOSURE="1"/>
  </inheritance>
- <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="FILL_CELL_FROM_ATTRIBUTES" VERSION="1" LANGU="E" DESCRIPT="Fill some cell properties from &lt;c&gt; element attributes" EXPOSURE="0" STATE="1" EDITORDER="2 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="FILL_CELL_FROM_ATTRIBUTES" SCONAME="IO_READER" VERSION="1" LANGU="E" DESCRIPT="SXML Reader Interface" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="3" TYPE="IF_SXML_READER"/>
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="FILL_CELL_FROM_ATTRIBUTES" SCONAME="ES_CELL" VERSION="1" LANGU="E" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="T_CELL"/>
-  <exception CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="FILL_CELL_FROM_ATTRIBUTES" SCONAME="LCX_NOT_FOUND" VERSION="1" LANGU="E" MTDTYPE="0" EDITORDER="1 "/>
+ <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="FILL_CELL_FROM_ATTRIBUTES" VERSION="1" LANGU="D" DESCRIPT="Fill some cell properties from &lt;c&gt; element attributes" EXPOSURE="0" STATE="1" EDITORDER="2 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="FILL_CELL_FROM_ATTRIBUTES" SCONAME="IO_READER" VERSION="1" LANGU="D" DESCRIPT="SXML Reader Interface" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="3" TYPE="IF_SXML_READER"/>
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="FILL_CELL_FROM_ATTRIBUTES" SCONAME="ES_CELL" VERSION="1" LANGU="D" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="T_CELL"/>
+  <exception CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="FILL_CELL_FROM_ATTRIBUTES" SCONAME="LCX_NOT_FOUND" VERSION="1" LANGU="D" MTDTYPE="0" EDITORDER="1 "/>
   <source>method FILL_CELL_FROM_ATTRIBUTES.
 
   while io_reader-&gt;node_type ne c_end_of_stream.
@@ -336,13 +389,11 @@ ENDCLASS.                    &quot;lcl_test IMPLEMENTATION</localTestClasses>
     endcase.
   endwhile.
 
-  io_reader-&gt;current_node( ).
-
 endmethod.</source>
  </method>
- <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_CELL_COORD" VERSION="1" LANGU="E" DESCRIPT='Cell coordinates from expression (like &quot;B2&quot;)' EXPOSURE="0" STATE="1" EDITORDER="4 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" BCMTDCAT="00" BCMTDSYN="0">
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_CELL_COORD" SCONAME="IV_COORD" VERSION="1" LANGU="E" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="STRING"/>
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_CELL_COORD" SCONAME="ES_COORD" VERSION="1" LANGU="E" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="T_CELL_COORD"/>
+ <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_CELL_COORD" VERSION="1" LANGU="D" DESCRIPT='Cell coordinates from expression (like &quot;B2&quot;)' EXPOSURE="0" STATE="1" EDITORDER="4 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" BCMTDCAT="00" BCMTDSYN="0">
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_CELL_COORD" SCONAME="IV_COORD" VERSION="1" LANGU="D" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="STRING"/>
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_CELL_COORD" SCONAME="ES_COORD" VERSION="1" LANGU="D" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="T_CELL_COORD"/>
   <source>method GET_CELL_COORD.
 
   zcl_excel_common=&gt;convert_columnrow2column_a_row(
@@ -355,10 +406,10 @@ endmethod.</source>
 
 endmethod.</source>
  </method>
- <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SHARED_STRING" VERSION="1" LANGU="E" DESCRIPT="Read from shared string table" EXPOSURE="0" STATE="1" EDITORDER="6 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SHARED_STRING" SCONAME="IV_INDEX" VERSION="1" LANGU="E" DESCRIPT="Zero-based Index" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="ANY"/>
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SHARED_STRING" SCONAME="EV_VALUE" VERSION="1" LANGU="E" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="STRING"/>
-  <exception CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SHARED_STRING" SCONAME="LCX_NOT_FOUND" VERSION="1" LANGU="E" MTDTYPE="0" EDITORDER="1 "/>
+ <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SHARED_STRING" VERSION="1" LANGU="D" DESCRIPT="Read from shared string table" EXPOSURE="0" STATE="1" EDITORDER="6 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SHARED_STRING" SCONAME="IV_INDEX" VERSION="1" LANGU="D" DESCRIPT="Zero-based Index" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="ANY"/>
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SHARED_STRING" SCONAME="EV_VALUE" VERSION="1" LANGU="D" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="STRING"/>
+  <exception CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SHARED_STRING" SCONAME="LCX_NOT_FOUND" VERSION="1" LANGU="D" MTDTYPE="0" EDITORDER="1 "/>
   <source>method GET_SHARED_STRING.
   data: lv_tabix type i.
   lv_tabix = iv_index + 1.
@@ -370,10 +421,10 @@ endmethod.</source>
   endif.
 endmethod.</source>
  </method>
- <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_STYLE" VERSION="1" LANGU="E" DESCRIPT="Read from style table" EXPOSURE="0" STATE="1" EDITORDER="7 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_STYLE" SCONAME="IV_INDEX" VERSION="1" LANGU="E" DESCRIPT="Zero-based Index" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="ANY"/>
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_STYLE" SCONAME="EV_STYLE_GUID" VERSION="1" LANGU="E" DESCRIPT="Style ID" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="ZEXCEL_CELL_STYLE"/>
-  <exception CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_STYLE" SCONAME="LCX_NOT_FOUND" VERSION="1" LANGU="E" MTDTYPE="0" EDITORDER="1 "/>
+ <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_STYLE" VERSION="1" LANGU="D" DESCRIPT="Read from style table" EXPOSURE="0" STATE="1" EDITORDER="7 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_STYLE" SCONAME="IV_INDEX" VERSION="1" LANGU="D" DESCRIPT="Zero-based Index" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="ANY"/>
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_STYLE" SCONAME="EV_STYLE_GUID" VERSION="1" LANGU="D" DESCRIPT="Style ID" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="ZEXCEL_CELL_STYLE"/>
+  <exception CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_STYLE" SCONAME="LCX_NOT_FOUND" VERSION="1" LANGU="D" MTDTYPE="0" EDITORDER="1 "/>
   <source>method GET_STYLE.
 
   data: lv_tabix type i,
@@ -396,10 +447,10 @@ endmethod.</source>
 
 endmethod.</source>
  </method>
- <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SXML_READER" VERSION="1" LANGU="E" DESCRIPT="Create an sXML reader for an XML file in the zip archive" EXPOSURE="0" STATE="1" EDITORDER="9 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SXML_READER" SCONAME="IV_PATH" VERSION="1" LANGU="E" DESCRIPT="Path of the file in the archive" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="STRING"/>
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SXML_READER" SCONAME="EO_READER" VERSION="1" LANGU="E" DESCRIPT="sXML reader" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="3" TYPE="IF_SXML_READER"/>
-  <exception CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SXML_READER" SCONAME="ZCX_EXCEL" VERSION="1" LANGU="E" DESCRIPT="Exceptions for ABAP2XLSX" MTDTYPE="0" EDITORDER="1 "/>
+ <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SXML_READER" VERSION="1" LANGU="D" DESCRIPT="Create an sXML reader for an XML file in the zip archive" EXPOSURE="0" STATE="1" EDITORDER="9 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SXML_READER" SCONAME="IV_PATH" VERSION="1" LANGU="D" DESCRIPT="Path of the file in the archive" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="STRING"/>
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SXML_READER" SCONAME="EO_READER" VERSION="1" LANGU="D" DESCRIPT="sXML reader" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="3" TYPE="IF_SXML_READER"/>
+  <exception CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="GET_SXML_READER" SCONAME="ZCX_EXCEL" VERSION="1" LANGU="D" DESCRIPT="Exceptions for ABAP2XLSX" MTDTYPE="0" EDITORDER="1 "/>
   <source>method GET_SXML_READER.
 
   data: lv_xml type xstring.
@@ -432,10 +483,13 @@ endmethod.</source>
 
 endmethod.</source>
  </method>
- <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="PUT_CELL_TO_WORKSHEET" VERSION="1" LANGU="E" DESCRIPT="Put cell data to worksheet" EXPOSURE="0" STATE="1" EDITORDER="5 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" BCMTDCAT="00" BCMTDSYN="0">
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="PUT_CELL_TO_WORKSHEET" SCONAME="IO_WORKSHEET" VERSION="1" LANGU="E" DESCRIPT="Worksheet" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="3" TYPE="ZCL_EXCEL_WORKSHEET"/>
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="PUT_CELL_TO_WORKSHEET" SCONAME="IS_CELL" VERSION="1" LANGU="E" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="T_CELL"/>
+ <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="PUT_CELL_TO_WORKSHEET" VERSION="1" LANGU="D" DESCRIPT="Put cell data to worksheet" EXPOSURE="0" STATE="1" EDITORDER="5 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" BCMTDCAT="00" BCMTDSYN="0">
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="PUT_CELL_TO_WORKSHEET" SCONAME="IO_WORKSHEET" VERSION="1" LANGU="D" DESCRIPT="Worksheet" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="3" TYPE="ZCL_EXCEL_WORKSHEET"/>
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="PUT_CELL_TO_WORKSHEET" SCONAME="IS_CELL" VERSION="1" LANGU="D" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="T_CELL"/>
   <source>method PUT_CELL_TO_WORKSHEET.
+  check is_cell-value is not initial
+     or is_cell-formula is not initial
+     or is_cell-style is not initial.
   call method io_worksheet-&gt;set_cell
     exporting
       ip_column    = is_cell-column
@@ -446,9 +500,9 @@ endmethod.</source>
       ip_style     = is_cell-style.
 endmethod.</source>
  </method>
- <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_SHARED_STRINGS" VERSION="1" LANGU="E" DESCRIPT="Reads the XML file containing the shared strings" EXPOSURE="0" STATE="1" EDITORDER="3 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" BCMTDCAT="00" BCMTDSYN="0">
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_SHARED_STRINGS" SCONAME="IO_READER" VERSION="1" LANGU="E" DESCRIPT="sXML reader" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="3" TYPE="IF_SXML_READER"/>
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_SHARED_STRINGS" SCONAME="ET_SHARED_STRINGS" VERSION="1" LANGU="E" DESCRIPT="Table with Strings" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="STRINGTAB"/>
+ <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_SHARED_STRINGS" VERSION="1" LANGU="D" DESCRIPT="Reads the XML file containing the shared strings" EXPOSURE="0" STATE="1" EDITORDER="3 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" BCMTDCAT="00" BCMTDSYN="0">
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_SHARED_STRINGS" SCONAME="IO_READER" VERSION="1" LANGU="D" DESCRIPT="sXML reader" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="3" TYPE="IF_SXML_READER"/>
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_SHARED_STRINGS" SCONAME="ET_SHARED_STRINGS" VERSION="1" LANGU="D" DESCRIPT="Table with Strings" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="STRINGTAB"/>
   <source>method READ_SHARED_STRINGS.
 
   while io_reader-&gt;node_type ne c_end_of_stream.
@@ -461,10 +515,10 @@ endmethod.</source>
 
 endmethod.</source>
  </method>
- <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_WORKSHEET_DATA" VERSION="1" LANGU="E" DESCRIPT="Reads the data, formula and styles of the worksheet&apos;s cells" EXPOSURE="0" STATE="1" EDITORDER="8 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_WORKSHEET_DATA" SCONAME="IO_READER" VERSION="1" LANGU="E" DESCRIPT="Worksheet reader" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="3" TYPE="IF_SXML_READER"/>
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_WORKSHEET_DATA" SCONAME="IO_WORKSHEET" VERSION="1" LANGU="E" DESCRIPT="Worksheet" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="3" TYPE="ZCL_EXCEL_WORKSHEET"/>
-  <exception CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_WORKSHEET_DATA" SCONAME="LCX_NOT_FOUND" VERSION="1" LANGU="E" MTDTYPE="0" EDITORDER="1 "/>
+ <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_WORKSHEET_DATA" VERSION="1" LANGU="D" DESCRIPT="Reads the data, formula and styles of the worksheet&apos;s cells" EXPOSURE="0" STATE="1" EDITORDER="8 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_WORKSHEET_DATA" SCONAME="IO_READER" VERSION="1" LANGU="D" DESCRIPT="Worksheet reader" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="3" TYPE="IF_SXML_READER"/>
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_WORKSHEET_DATA" SCONAME="IO_WORKSHEET" VERSION="1" LANGU="D" DESCRIPT="Worksheet" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="3" TYPE="ZCL_EXCEL_WORKSHEET"/>
+  <exception CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="READ_WORKSHEET_DATA" SCONAME="LCX_NOT_FOUND" VERSION="1" LANGU="D" MTDTYPE="0" EDITORDER="1 "/>
   <source>method READ_WORKSHEET_DATA.
 
   data: ls_cell   type t_cell.
@@ -480,20 +534,23 @@ endmethod.</source>
         if io_reader-&gt;name eq `c`.
           ls_cell = fill_cell_from_attributes( io_reader ).
         endif.
-      when c_element_close.
+      when c_node_value.
         case io_reader-&gt;name.
-          when `c`.
-            put_cell_to_worksheet( is_cell = ls_cell io_worksheet = io_worksheet ).
           when `f`.
             ls_cell-formula = io_reader-&gt;value.
           when `v`.
             if ls_cell-datatype eq `s`.
-              ls_cell-value = get_shared_string( ls_cell-value ).
+              ls_cell-value = get_shared_string( io_reader-&gt;value ).
             else.
               ls_cell-value = io_reader-&gt;value.
             endif.
-          when `is`.
+          when `t` or `is`.
             ls_cell-value = io_reader-&gt;value.
+        endcase.
+      when c_element_close.
+        case io_reader-&gt;name.
+          when `c`.
+            put_cell_to_worksheet( is_cell = ls_cell io_worksheet = io_worksheet ).
           when `sheetData`.
             exit.
         endcase.
@@ -502,10 +559,10 @@ endmethod.</source>
 
 endmethod.</source>
  </method>
- <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="SKIP_TO" VERSION="1" LANGU="E" DESCRIPT="Go ahead till element with given name is found" EXPOSURE="0" STATE="1" EDITORDER="1 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="SKIP_TO" SCONAME="IV_ELEMENT_NAME" VERSION="1" LANGU="E" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="STRING"/>
-  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="SKIP_TO" SCONAME="IO_READER" VERSION="1" LANGU="E" DESCRIPT="SXML Reader Interface" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="3" TYPE="IF_SXML_READER"/>
-  <exception CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="SKIP_TO" SCONAME="LCX_NOT_FOUND" VERSION="1" LANGU="E" MTDTYPE="0" EDITORDER="1 "/>
+ <method CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="SKIP_TO" VERSION="1" LANGU="D" DESCRIPT="Go ahead till element with given name is found" EXPOSURE="0" STATE="1" EDITORDER="1 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="SKIP_TO" SCONAME="IV_ELEMENT_NAME" VERSION="1" LANGU="D" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="STRING"/>
+  <parameter CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="SKIP_TO" SCONAME="IO_READER" VERSION="1" LANGU="D" DESCRIPT="SXML Reader Interface" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="3" TYPE="IF_SXML_READER"/>
+  <exception CLSNAME="ZCL_EXCEL_READER_HUGE_FILE" CMPNAME="SKIP_TO" SCONAME="LCX_NOT_FOUND" VERSION="1" LANGU="D" MTDTYPE="0" EDITORDER="1 "/>
   <source>method SKIP_TO.
 
 * Skip forward to given element


### PR DESCRIPTION
There was a bug in reading strings from the SST, caused by not catching the "node value" event in the main loop. Shared strings could point wrongly to the first table element (which usually contains the empty string). My tests didn't detect the bug since I worked with tables containing only one string. I extended them to catch this bug, before fixing it.
The delta display is a bit weird, probably due to different line feed symbols? My changes are mainly in method READ_WORKSHEET_DATA
