### PR TITLE
Get style id from mapping table (column style)

### DIFF
--- a/ZA2X/CLAS/ZCL_EXCEL_WRITER_2007.slnk
+++ b/ZA2X/CLAS/ZCL_EXCEL_WRITER_2007.slnk
@@ -3221,7 +3221,9 @@
 *        lv_value = &lt;column_dimension&gt;-column_dimension-&gt;get_xf_index( ).                                   &quot;del issue #157 -  set column style
         lv_style_guid = &lt;column_dimension&gt;-column_dimension-&gt;get_column_style_guid( ).                      &quot;ins issue #157 -  set column style
 *        lv_value = me-&gt;excel-&gt;get_style_index_in_styles( lv_style_guid ).                                  &quot;del issue #237
-        lv_style_index = me-&gt;excel-&gt;get_style_index_in_styles( lv_style_guid ).                             &quot;ins issue #237
+        CLEAR ls_style_mapping.
+        READ TABLE styles_mapping INTO ls_style_mapping WITH KEY guid = lv_style_guid.
+        lv_style_index = ls_style_mapping-style.
         IF lv_style_index &gt; 0.                                                                              &quot;ins issue #237
           lv_value = lv_style_index - 1.                                                                    &quot;ins issue #237
           SHIFT lv_value RIGHT DELETING TRAILING space.


### PR DESCRIPTION
Global mapping table styles_mapping should be used for column styles as well. It is already used for other styles.
