### PR TITLE
Ignore merged cells when calculating column width

### DIFF
--- a/ZA2X/CLAS/ZCL_EXCEL_COMMON.slnk
+++ b/ZA2X/CLAS/ZCL_EXCEL_COMMON.slnk
@@ -65,6 +65,7 @@ CLASS lcl_excel_common_test DEFINITION FOR TESTING  &quot;#AU Risk_Level Harmles
     METHODS: describe_structure FOR TESTING.
     METHODS: calculate_cell_distance FOR TESTING.
     METHODS: shift_formula FOR TESTING.
+    METHODS: is_cell_in_range FOR TESTING.
 ENDCLASS.       &quot;lcl_Excel_Common_Test
 
 
@@ -1036,9 +1037,117 @@ CLASS lcl_excel_common_test IMPLEMENTATION.
           &apos;A1+$A1+A$1+$A$1+B2&apos;                  -1  -1       &apos;#REF!+#REF!+#REF!+$A$1+A1&apos;. &quot; Referencing error , row and column , underflow
   ENDMETHOD.                    &quot;SHIFT_FORMULA
 
+  METHOD is_cell_in_range.
+    DATA ep_cell_in_range TYPE abap_bool.
 
+* Test 1: upper left corner (in range)
+    TRY.
+      ep_cell_in_range = zcl_excel_common=&gt;is_cell_in_range(
+          ip_column   = &apos;B&apos;
+          ip_row      = 2
+          ip_range    = &apos;B2:D4&apos; ).
 
+      zcl_excel_common=&gt;assert_equals(
+          act   = ep_cell_in_range
+          exp   = abap_true
+          msg   = &apos;Check cell in range failed&apos;
+          level = if_aunit_constants=&gt;critical ).
+     CATCH zcx_excel.
+        zcl_excel_common=&gt;fail(
+            msg    = &apos;Unexpected exception&apos;
+            level  = if_aunit_constants=&gt;critical ).
+    ENDTRY.
 
+* Test 2: lower right corner (in range)
+    TRY.
+      ep_cell_in_range = zcl_excel_common=&gt;is_cell_in_range(
+          ip_column   = &apos;D&apos;
+          ip_row      = 4
+          ip_range    = &apos;B2:D4&apos; ).
+
+      zcl_excel_common=&gt;assert_equals(
+          act   = ep_cell_in_range
+          exp   = abap_true
+          msg   = &apos;Check cell in range failed&apos;
+          level = if_aunit_constants=&gt;critical ).
+     CATCH zcx_excel.
+        zcl_excel_common=&gt;fail(
+            msg    = &apos;Unexpected exception&apos;
+            level  = if_aunit_constants=&gt;critical ).
+    ENDTRY.
+
+* Test 3: left side (out of range)
+    TRY.
+      ep_cell_in_range = zcl_excel_common=&gt;is_cell_in_range(
+          ip_column   = &apos;A&apos;
+          ip_row      = 3
+          ip_range    = &apos;B2:D4&apos; ).
+
+      zcl_excel_common=&gt;assert_equals(
+          act   = ep_cell_in_range
+          exp   = abap_false
+          msg   = &apos;Check cell in range failed&apos;
+          level = if_aunit_constants=&gt;critical ).
+     CATCH zcx_excel.
+        zcl_excel_common=&gt;fail(
+            msg    = &apos;Unexpected exception&apos;
+            level  = if_aunit_constants=&gt;critical ).
+    ENDTRY.
+
+* Test 4: upper side (out of range)
+    TRY.
+      ep_cell_in_range = zcl_excel_common=&gt;is_cell_in_range(
+          ip_column   = &apos;C&apos;
+          ip_row      = 1
+          ip_range    = &apos;B2:D4&apos; ).
+
+      zcl_excel_common=&gt;assert_equals(
+          act   = ep_cell_in_range
+          exp   = abap_false
+          msg   = &apos;Check cell in range failed&apos;
+          level = if_aunit_constants=&gt;critical ).
+     CATCH zcx_excel.
+        zcl_excel_common=&gt;fail(
+            msg    = &apos;Unexpected exception&apos;
+            level  = if_aunit_constants=&gt;critical ).
+    ENDTRY.
+
+* Test 5: right side (out of range)
+    TRY.
+      ep_cell_in_range = zcl_excel_common=&gt;is_cell_in_range(
+          ip_column   = &apos;E&apos;
+          ip_row      = 3
+          ip_range    = &apos;B2:D4&apos; ).
+
+      zcl_excel_common=&gt;assert_equals(
+          act   = ep_cell_in_range
+          exp   = abap_false
+          msg   = &apos;Check cell in range failed&apos;
+          level = if_aunit_constants=&gt;critical ).
+     CATCH zcx_excel.
+        zcl_excel_common=&gt;fail(
+            msg    = &apos;Unexpected exception&apos;
+            level  = if_aunit_constants=&gt;critical ).
+    ENDTRY.
+
+* Test 6: lower side (out of range)
+    TRY.
+      ep_cell_in_range = zcl_excel_common=&gt;is_cell_in_range(
+          ip_column   = &apos;C&apos;
+          ip_row      = 5
+          ip_range    = &apos;B2:D4&apos; ).
+
+      zcl_excel_common=&gt;assert_equals(
+          act   = ep_cell_in_range
+          exp   = abap_false
+          msg   = &apos;Check cell in range failed&apos;
+          level = if_aunit_constants=&gt;critical ).
+     CATCH zcx_excel.
+        zcl_excel_common=&gt;fail(
+            msg    = &apos;Unexpected exception&apos;
+            level  = if_aunit_constants=&gt;critical ).
+    ENDTRY.
+  ENDMETHOD.
 
 ENDCLASS.       &quot;lcl_Excel_Common_Test</localTestClasses>
  <textPool>

--- a/ZA2X/CLAS/ZCL_EXCEL_COMMON.slnk
+++ b/ZA2X/CLAS/ZCL_EXCEL_COMMON.slnk
@@ -1888,6 +1888,46 @@ endmethod.</source>
 
 endmethod.</source>
  </method>
+  <method CLSNAME="ZCL_EXCEL_COMMON" CMPNAME="IS_CELL_IN_RANGE" VERSION="1" LANGU="E" DESCRIPT="Check if cell is part of a range" EXPOSURE="2" STATE="1" EDITORDER="24 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="1" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
+  <parameter CLSNAME="ZCL_EXCEL_COMMON" CMPNAME="IS_CELL_IN_RANGE" SCONAME="IP_COLUMN" VERSION="1" LANGU="E" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="SIMPLE"/>
+  <parameter CLSNAME="ZCL_EXCEL_COMMON" CMPNAME="IS_CELL_IN_RANGE" SCONAME="IP_ROW" VERSION="1" LANGU="E" DESCRIPT="Cell Row" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="ZEXCEL_CELL_ROW"/>
+  <parameter CLSNAME="ZCL_EXCEL_COMMON" CMPNAME="IS_CELL_IN_RANGE" SCONAME="IP_RANGE" VERSION="1" LANGU="E" CMPTYPE="1" MTDTYPE="0" EDITORDER="3 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="CLIKE"/>
+  <parameter CLSNAME="ZCL_EXCEL_COMMON" CMPNAME="IS_CELL_IN_RANGE" SCONAME="RP_IN_RANGE" VERSION="1" LANGU="E" CMPTYPE="1" MTDTYPE="0" EDITORDER="4 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="ABAP_BOOL"/>
+  <exception CLSNAME="ZCL_EXCEL_COMMON" CMPNAME="IS_CELL_IN_RANGE" SCONAME="ZCX_EXCEL" VERSION="1" LANGU="E" DESCRIPT="Exceptions for ABAP2XLSX" MTDTYPE="0" EDITORDER="1 "/>
+  <source>method IS_CELL_IN_RANGE.
+  DATA lv_column_start    TYPE zexcel_cell_column_alpha.
+  DATA lv_column_end      TYPE zexcel_cell_column_alpha.
+  DATA lv_row_start       TYPE zexcel_cell_row.
+  DATA lv_row_end         TYPE zexcel_cell_row.
+  DATA lv_column_start_i  TYPE zexcel_cell_column.
+  DATA lv_column_end_i    TYPE zexcel_cell_column.
+  DATA lv_column_i        TYPE zexcel_cell_column.
+
+
+* Split range and convert columns
+  convert_range2column_a_row(
+    exporting
+      i_range        = ip_range
+    IMPORTING
+      e_column_start = lv_column_start
+      e_column_end   = lv_column_end
+      e_row_start    = lv_row_start
+      e_row_end      = lv_row_end ).
+
+  lv_column_start_i = convert_column2int( ip_column = lv_column_start ).
+  lv_column_end_i   = convert_column2int( ip_column = lv_column_end ).
+
+  lv_column_i = convert_column2int( ip_column = ip_column ).
+
+* Check if cell is in range
+  IF lv_column_i &gt;= lv_column_start_i AND
+     lv_column_i &lt;= lv_column_end_i   AND
+     ip_row      &gt;= lv_row_start      AND
+     ip_row      &lt;= lv_row_end.
+    rp_in_range = abap_true.
+  ENDIF.
+endmethod.</source>
+ </method>
  <method CLSNAME="ZCL_EXCEL_COMMON" CMPNAME="NUMBER_TO_EXCEL_STRING" VERSION="1" LANGU="E" DESCRIPT="Converts number to string representation in Excel format" EXPOSURE="2" STATE="1" EDITORDER="13 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="1" BCMTDCAT="00" BCMTDSYN="0">
   <parameter CLSNAME="ZCL_EXCEL_COMMON" CMPNAME="NUMBER_TO_EXCEL_STRING" SCONAME="IP_VALUE" VERSION="1" LANGU="E" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="0" TYPTYPE="1" TYPE="NUMERIC"/>
   <parameter CLSNAME="ZCL_EXCEL_COMMON" CMPNAME="NUMBER_TO_EXCEL_STRING" SCONAME="EP_VALUE" VERSION="1" LANGU="E" DESCRIPT="Cell Value" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="ZEXCEL_CELL_VALUE"/>

--- a/ZA2X/CLAS/ZCL_EXCEL_WORKSHEET.slnk
+++ b/ZA2X/CLAS/ZCL_EXCEL_WORKSHEET.slnk
@@ -3174,6 +3174,10 @@ ENDMETHOD.</source>
 *      col_alpha = zcl_excel_common=&gt;convert_column2alpha( &lt;auto_size&gt;-col_index ).&quot; issue #155 - less restrictive typing for ip_column
       count = 1.
       WHILE count &lt;= highest_row.
+* Do not check merged cells
+        IF is_cell_merged(
+            ip_column    = &lt;auto_size&gt;-col_index
+            ip_row       = count ) = abap_false.
 * Start of change # issue 139 - Dateretention of cellstyles
 *        IF cell_style IS BOUND.
 *          CREATE OBJECT cell_style.
@@ -3195,11 +3199,12 @@ ENDMETHOD.</source>
 *          width = cell_style-&gt;font-&gt;calculate_text_width( cell_value ).
 *        ENDIF.
 *        width = calculate_cell_width( ip_column = col_alpha                &quot; issue #155 - less restrictive typing for ip_column
-        width = calculate_cell_width( ip_column = &lt;auto_size&gt;-col_index     &quot; issue #155 - less restrictive typing for ip_column
-                                      ip_row    = count ).
+         width = calculate_cell_width( ip_column = &lt;auto_size&gt;-col_index     &quot; issue #155 - less restrictive typing for ip_column
+                                       ip_row    = count ).
 * End of change # issue 139 - Dateretention of cellstyles
-        IF width &gt; &lt;auto_size&gt;-width.
-          &lt;auto_size&gt;-width = width.
+         IF width &gt; &lt;auto_size&gt;-width.
+           &lt;auto_size&gt;-width = width.
+         ENDIF.
         ENDIF.
         count = count + 1.
       ENDWHILE.

--- a/ZA2X/CLAS/ZCL_EXCEL_WORKSHEET.slnk
+++ b/ZA2X/CLAS/ZCL_EXCEL_WORKSHEET.slnk
@@ -4234,6 +4234,30 @@ ENDMETHOD.</source>
 
   endmethod.</source>
  </method>
+  <method CLSNAME="ZCL_EXCEL_WORKSHEET" CMPNAME="IS_CELL_MERGED" VERSION="1" LANGU="E" DESCRIPT="Checks if a cell is merged" EXPOSURE="2" STATE="1" EDITORDER="59 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" MTDNEWEXC="X" BCMTDCAT="00" BCMTDSYN="0">
+  <parameter CLSNAME="ZCL_EXCEL_WORKSHEET" CMPNAME="IS_CELL_MERGED" SCONAME="IP_COLUMN" VERSION="1" LANGU="E" CMPTYPE="1" MTDTYPE="0" EDITORDER="1 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="SIMPLE"/>
+  <parameter CLSNAME="ZCL_EXCEL_WORKSHEET" CMPNAME="IS_CELL_MERGED" SCONAME="IP_ROW" VERSION="1" LANGU="E" DESCRIPT="Cell Row" CMPTYPE="1" MTDTYPE="0" EDITORDER="2 " DISPID="0 " PARDECLTYP="0" PARPASSTYP="1" TYPTYPE="1" TYPE="ZEXCEL_CELL_ROW"/>
+  <parameter CLSNAME="ZCL_EXCEL_WORKSHEET" CMPNAME="IS_CELL_MERGED" SCONAME="RP_IS_MERGED" VERSION="1" LANGU="E" CMPTYPE="1" MTDTYPE="0" EDITORDER="3 " DISPID="0 " PARDECLTYP="3" PARPASSTYP="0" TYPTYPE="1" TYPE="ABAP_BOOL"/>
+  <exception CLSNAME="ZCL_EXCEL_WORKSHEET" CMPNAME="IS_CELL_MERGED" SCONAME="ZCX_EXCEL" VERSION="1" LANGU="E" DESCRIPT="Exceptions for ABAP2XLSX" MTDTYPE="0" EDITORDER="1 "/>
+  <source>method IS_CELL_MERGED.
+  DATA lt_merge_range TYPE string_table.
+
+  FIELD-SYMBOLS &lt;lv_merge_range&gt;  LIKE LINE OF lt_merge_range.
+
+
+  lt_merge_range = me-&gt;get_merge( ).
+
+  LOOP AT lt_merge_range ASSIGNING &lt;lv_merge_range&gt;.
+    rp_is_merged = zcl_excel_common=&gt;is_cell_in_range(
+        ip_column   = ip_column
+        ip_row      = ip_row
+        ip_range    = &lt;lv_merge_range&gt; ).
+    IF rp_is_merged = abap_true.
+      EXIT.
+    ENDIF.
+  ENDLOOP.
+endmethod.</source>
+ </method>
  <method CLSNAME="ZCL_EXCEL_WORKSHEET" CMPNAME="PRINT_TITLE_SET_RANGE" VERSION="1" LANGU="E" DESCRIPT="Update range for print title" EXPOSURE="0" STATE="1" EDITORDER="58 " DISPID="0 " MTDTYPE="0" MTDDECLTYP="0" BCMTDCAT="00" BCMTDSYN="0">
   <source>method PRINT_TITLE_SET_RANGE.
 *--------------------------------------------------------------------*

--- a/ZA2X/PROG/ZDEMO_EXCEL31.slnk
+++ b/ZA2X/PROG/ZDEMO_EXCEL31.slnk
@@ -142,6 +142,23 @@ START-OF-SELECTION.
   column_dimension = lo_worksheet-&gt;get_column_dimension( &apos;C&apos; ).
   column_dimension-&gt;set_auto_size( ip_auto_size = abap_true ).
 
+  &quot; Add sheet for merged cells
+  lo_worksheet = lo_excel-&gt;add_new_worksheet( ).
+  lo_worksheet-&gt;set_title( ip_title = &apos;Merged cells&apos; ).
+
+  lo_worksheet-&gt;set_cell( ip_column = &apos;A&apos; ip_row = 1 ip_value = &apos;This is a very long header text&apos; ).
+  lo_worksheet-&gt;set_cell( ip_column = &apos;A&apos; ip_row = 2 ip_value = &apos;Some data&apos; ).
+  lo_worksheet-&gt;set_cell( ip_column = &apos;A&apos; ip_row = 3 ip_value = &apos;Some more data&apos; ).
+
+  lo_worksheet-&gt;set_merge(
+    EXPORTING
+      ip_column_start = &apos;A&apos;
+      ip_column_end   = &apos;C&apos;
+      ip_row          = 1 ).
+
+  column_dimension = lo_worksheet-&gt;get_column_dimension( &apos;A&apos; ).
+  column_dimension-&gt;set_auto_size( ip_auto_size = abap_true ).
+
   lo_excel-&gt;set_active_sheet_index( i_active_worksheet = 1 ).
 
 *** Create output


### PR DESCRIPTION
When calculating column width cells that are merged should be ignored. This is MS Excel behavior and should be handled similar in ABAP2XLSX.
