### PR TITLE
Style of remaining columns with no values

### DIFF
--- a/ZA2X/CLAS/ZCL_EXCEL_READER_2007.slnk
+++ b/ZA2X/CLAS/ZCL_EXCEL_READER_2007.slnk
@@ -2776,10 +2776,14 @@ ENDMETHOD.</source>
     ENDIF.
 
 * issue #367 - hide columns from
-    IF    ls_column-max    = 16384 &quot; Max = very right column
-      AND ls_column-hidden = 1     &quot; all hidden
-      AND ls_column-min    &gt; 0.
-      io_worksheet-&gt;zif_excel_sheet_properties~hide_columns_from = zcl_excel_common=&gt;convert_column2alpha( ls_column-min ).
+    IF ls_column-max = zcl_excel_common=&gt;c_excel_sheet_max_col     &quot; Max = very right column
+      IF ls_column-hidden = 1     &quot; all hidden
+        AND ls_column-min &gt; 0.
+       io_worksheet-&gt;zif_excel_sheet_properties~hide_columns_from = zcl_excel_common=&gt;convert_column2alpha( ls_column-min ).
+      ELSEIF ls_column-style &gt; &apos;&apos;.
+* Set default style for remaining columns
+       io_worksheet-&gt;zif_excel_sheet_properties~set_style( dummy_zexcel_cell_style ).
+      ENDIF.
     ENDIF.
 
 


### PR DESCRIPTION
When setting a style for all columns the reader only reads this style for filled columns. The style of the remaining columns is dropped.
Example: You activate border lines for all cells, but you fill only the first three columns. After reading and writing it with ABAP2XLSX, only the first three columns have border lines.

This is fixed by setting the default style here.
