### PR TITLE
Issue on duplicated cell values at create_xl_sharedstrings #461

### DIFF
--- a/ZA2X/CLAS/ZCL_EXCEL_WRITER_2007.slnk
+++ b/ZA2X/CLAS/ZCL_EXCEL_WRITER_2007.slnk
@@ -2728,6 +2728,11 @@ ENDMETHOD.</source>
   SHIFT lv_count_str LEFT DELETING LEADING space.
 
   SORT lt_cell_data BY cell_value.
+* Remove all non-strings first to avoid deleting same cell values in a
+* non-string cell
+  DELETE lt_cell_data WHERE data_type &lt;&gt; &apos;s&apos;.
+
+* Safely remove duplicated string cells
   DELETE ADJACENT DUPLICATES FROM lt_cell_data COMPARING cell_value.
 
   DESCRIBE TABLE lt_cell_data LINES lv_uniquecount.


### PR DESCRIPTION
The class ZCL_EXCEL_WRITER_2007 has a small problem writing a sheet containing two cells with same value but of different types, i.e. one string '5' and numeral 5 .

In this case the string 5 will not be created at create_xl_sharedstrings and a random string (index 0) will be used to generate the file.
