### PR TITLE
Method DATE_TO_EXCEL_STRING: Date field = space

### DIFF
--- a/ZA2X/CLAS/ZCL_EXCEL_COMMON.slnk
+++ b/ZA2X/CLAS/ZCL_EXCEL_COMMON.slnk
@@ -1673,7 +1673,8 @@ endmethod.</source>
   <source>method DATE_TO_EXCEL_STRING.
   DATA: lv_date_diff         TYPE i.
 
-  CHECK ip_value IS NOT INITIAL.
+  CHECK ip_value IS NOT INITIAL
+    AND ip_value &lt;&gt; space.
   &quot; Needed hack caused by the problem that:
   &quot; Excel 2000 incorrectly assumes that the year 1900 is a leap year
   &quot; http://support.microsoft.com/kb/214326/en-us


### PR DESCRIPTION
Sometimes you get date field empty - containing only space(s) (not zeroes '00000000'). This value treated as not initial in ABAP for fields typed as D. This resulted in passing by
  CHECK ip_value IS NOT INITIAL
and calculating
  lv_date_diff = ip_value - c_excel_baseline_date + 1.
which returns "-693596". In EXCEL this displayed as #########...
