### PR TITLE
Optimization

### DIFF
--- a/ZA2X/CLAS/ZCL_EXCEL_COMMON.slnk
+++ b/ZA2X/CLAS/ZCL_EXCEL_COMMON.slnk
@@ -1362,6 +1362,9 @@ ENDMETHOD.</source>
               lv_module                       TYPE int4,
               lv_column                       TYPE zexcel_cell_column.
 
+  STATICS:    sv_prev_in  LIKE lv_column,
+              sv_prev_out LIKE ep_column.
+
 * Propagate zcx_excel if error occurs           &quot; issue #155 - less restrictive typing for ip_column
   lv_column = convert_column2int( ip_column ).  &quot; issue #155 - less restrictive typing for ip_column
 
@@ -1373,6 +1376,17 @@ ENDMETHOD.</source>
     RAISE EXCEPTION TYPE zcx_excel
       EXPORTING
         error = &apos;Index out of bounds&apos;.
+  ENDIF.
+
+*--------------------------------------------------------------------*
+* Look up for previous succesfull cached result
+*--------------------------------------------------------------------*
+  IF lv_column = sv_prev_in AND sv_prev_out IS NOT INITIAL.
+    ep_column = sv_prev_out.
+    RETURN.
+  ELSE.
+    CLEAR sv_prev_out.
+    sv_prev_in  = lv_column.
   ENDIF.
 
 *--------------------------------------------------------------------*
@@ -1389,6 +1403,11 @@ ENDMETHOD.</source>
     CONCATENATE lv_text ep_column INTO ep_column.
 
   ENDWHILE.
+
+*--------------------------------------------------------------------*
+* Save succesfull output into cache
+*--------------------------------------------------------------------*
+  sv_prev_out = ep_column.
 
 ENDMETHOD.</source>
  </method>
@@ -1423,6 +1442,8 @@ ENDMETHOD.</source>
               lv_errormessage                 TYPE string,                          &quot; Can&apos;t pass &apos;...&apos;(abc) to exception-class
               lv_modulo                       TYPE i.
 
+  STATICS:    sv_prev_in  LIKE lv_column_c,
+              sv_prev_out LIKE ep_column.
 *--------------------------------------------------------------------*
 * This module tries to identify which column a user wants to access
 * Numbers as input are just passed back, anything else will be converted
@@ -1445,6 +1466,17 @@ ENDMETHOD.</source>
     RAISE EXCEPTION TYPE zcx_excel
       EXPORTING
         syst_at_raise = syst.
+  ENDIF.
+
+*--------------------------------------------------------------------*
+* Look up for previous succesfull cached result
+*--------------------------------------------------------------------*
+  IF lv_column_c = sv_prev_in AND sv_prev_out IS NOT INITIAL.
+    ep_column = sv_prev_out.
+    RETURN.
+  ELSE.
+    CLEAR sv_prev_out.
+    sv_prev_in  = lv_column_c.
   ENDIF.
 
 *--------------------------------------------------------------------*
@@ -1484,59 +1516,61 @@ ENDMETHOD.</source>
         syst_at_raise = syst.
   ENDIF.
 
+  DO 1 TIMES. &quot;Because of using CHECK
 *--------------------------------------------------------------------*
 * Interpret input as number to base 26 with A=1, ... Z=26
 * Raise error if unexpected character turns up
 *--------------------------------------------------------------------*
 * 1st character
 *--------------------------------------------------------------------*
-  lv_column = lv_column_c.
-  lv_modulo = cl_abap_conv_out_ce=&gt;uccpi( lv_column+0(1) ) MOD zcl_excel_common=&gt;c_excel_col_module.
-  IF lv_modulo &lt; 1 OR lv_modulo &gt; 26.
+    lv_column = lv_column_c.
+    lv_modulo = cl_abap_conv_out_ce=&gt;uccpi( lv_column+0(1) ) MOD zcl_excel_common=&gt;c_excel_col_module.
+    IF lv_modulo &lt; 1 OR lv_modulo &gt; 26.
 *    lv_errormessage = &apos;Unable to interpret input as column&apos;(003).
 *    RAISE EXCEPTION TYPE zcx_excel
 *      EXPORTING
 *        error = lv_errormessage.
-    MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        syst_at_raise = syst.
-  ENDIF.
-  ep_column = lv_modulo.                    &quot; Leftmost digit
+      MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
+      RAISE EXCEPTION TYPE zcx_excel
+        EXPORTING
+          syst_at_raise = syst.
+    ENDIF.
+    ep_column = lv_modulo.                    &quot; Leftmost digit
 
 *--------------------------------------------------------------------*
 * 2nd character if present
 *--------------------------------------------------------------------*
-  CHECK lv_column+1(1) IS NOT INITIAL.      &quot; No need to continue if string ended
-  lv_modulo = cl_abap_conv_out_ce=&gt;uccpi( lv_column+1(1) ) MOD zcl_excel_common=&gt;c_excel_col_module.
-  IF lv_modulo &lt; 1 OR lv_modulo &gt; 26.
+    CHECK lv_column+1(1) IS NOT INITIAL.      &quot; No need to continue if string ended
+    lv_modulo = cl_abap_conv_out_ce=&gt;uccpi( lv_column+1(1) ) MOD zcl_excel_common=&gt;c_excel_col_module.
+    IF lv_modulo &lt; 1 OR lv_modulo &gt; 26.
 *    lv_errormessage = &apos;Unable to interpret input as column&apos;(003).
 *    RAISE EXCEPTION TYPE zcx_excel
 *      EXPORTING
 *        error = lv_errormessage.
-    MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        syst_at_raise = syst.
-  ENDIF.
-  ep_column = 26 * ep_column + lv_modulo.   &quot; if second digit is present first digit is for 26^1
+      MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
+      RAISE EXCEPTION TYPE zcx_excel
+        EXPORTING
+          syst_at_raise = syst.
+    ENDIF.
+    ep_column = 26 * ep_column + lv_modulo.   &quot; if second digit is present first digit is for 26^1
 
 *--------------------------------------------------------------------*
 * 3rd character if present
 *--------------------------------------------------------------------*
-  CHECK lv_column+2(1) IS NOT INITIAL.      &quot; No need to continue if string ended
-  lv_modulo = cl_abap_conv_out_ce=&gt;uccpi( lv_column+2(1) ) MOD zcl_excel_common=&gt;c_excel_col_module.
-  IF lv_modulo &lt; 1 OR lv_modulo &gt; 26.
+    CHECK lv_column+2(1) IS NOT INITIAL.      &quot; No need to continue if string ended
+    lv_modulo = cl_abap_conv_out_ce=&gt;uccpi( lv_column+2(1) ) MOD zcl_excel_common=&gt;c_excel_col_module.
+    IF lv_modulo &lt; 1 OR lv_modulo &gt; 26.
 *    lv_errormessage = &apos;Unable to interpret input as column&apos;(003).
 *    RAISE EXCEPTION TYPE zcx_excel
 *      EXPORTING
 *        error = lv_errormessage.
-    MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        syst_at_raise = syst.
-  ENDIF.
-  ep_column = 26 * ep_column + lv_modulo.   &quot; if third digit is present first digit is for 26^2 and second digit for 26^1
+      MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
+      RAISE EXCEPTION TYPE zcx_excel
+        EXPORTING
+          syst_at_raise = syst.
+    ENDIF.
+    ep_column = 26 * ep_column + lv_modulo.   &quot; if third digit is present first digit is for 26^2 and second digit for 26^1
+  ENDDO.
 
 *--------------------------------------------------------------------*
 * Maximum column for EXCEL:  XFD = 16384    &quot; if anyone has a reference for this information - please add here instead of this comment
@@ -1548,6 +1582,10 @@ ENDMETHOD.</source>
         error = lv_errormessage.
   ENDIF.
 
+*--------------------------------------------------------------------*
+* Save succesfull output into cache
+*--------------------------------------------------------------------*
+  sv_prev_out = ep_column.
 
 ENDMETHOD.</source>
  </method>


### PR DESCRIPTION
I was benchmarking exporting large tables to excel and found that big time take calls of methods:
ZCL_EXCEL_COMMON=>CONVERT_COLUMN2INT
ZCL_EXCEL_COMMON=>CONVERT_COLUMN2ALPHA
The most time take dealing with Unicode Code Point converting characters in and out (CL_ABAP_CONV*). 
![image](https://cloud.githubusercontent.com/assets/6097762/22251687/bc82b282-e25c-11e6-98fe-58a15f55de2c.png)
This can be improved because when going for example in one column from top to bottom (as method BIND_TABLE do) you always have the same column coordinate and it is not necessary to calculate its address every time. 
![image](https://cloud.githubusercontent.com/assets/6097762/22251724/e03c74ba-e25c-11e6-8e17-ffe58e1abba1.png)

So I was thinking about some cache table. But when you have too much iterations then even reading hashed table could take time in gross. But this was not tested.
The way I choose was to cache last value in methods CONVERT_COLUMN* in statics variables. This could give advantage when going column by column.
I've conducted some tests. Here is the test program.
```ABAP
*&---------------------------------------------------------------------*
*& Report  ZTEST_A2X
*&---------------------------------------------------------------------*
REPORT  ztest_a2x.
CONSTANTS: gc_save_file_name TYPE string VALUE 'ZTEST_A2X.xlsx'.
INCLUDE zdemo_excel_outputopt_incl.
PARAMETERS:
  p_size TYPE i DEFAULT 10000.
START-OF-SELECTION.
  PERFORM main.
*&---------------------------------------------------------------------*
*&      Form  main
*&---------------------------------------------------------------------*
FORM main.
  DATA:
    lo_excel     TYPE REF TO zcl_excel,
    lo_worksheet TYPE REF TO zcl_excel_worksheet,
    lt_data      TYPE TABLE OF anla.
*--------------------------------------------------------------------*
  SELECT * INTO TABLE lt_data  FROM anla UP TO p_size ROWS.
  WHILE lines( lt_data ) BETWEEN 1 AND p_size.
    APPEND LINES OF lt_data TO lt_data.
  ENDWHILE.
  DELETE lt_data FROM p_size + 1.
  "Have exactly p_size records in lt_data[] here
  CREATE OBJECT lo_excel.
  lo_worksheet = lo_excel->get_active_worksheet( ).
  SET RUN TIME ANALYZER ON.
  lo_worksheet->bind_table( ip_table = lt_data ).
  lcl_output=>output(
    cl_excel            = lo_excel
    iv_writerclass_name = 'ZCL_EXCEL_WRITER_HUGE_FILE'
  ).
  SET RUN TIME ANALYZER OFF.
ENDFORM.                    "main
```
Two steps were measured: BIND_TABLE and OUTPUT. The first one deals with column address conversions. The second one deals with XML and this is not the subject of optimization - just for comparison.
Results are promising:
![image](https://cloud.githubusercontent.com/assets/6097762/22251334/73242c0c-e25b-11e6-9a05-404f0839c0cd.png)
![image](https://cloud.githubusercontent.com/assets/6097762/22251345/7b1ca420-e25b-11e6-919c-c920539907be.png)
Method BIND_TABLE runs about 30% faster.
The time and number of calls to CL_ABAP_CONV* greatly decreased. It is not even on the first page.
![image](https://cloud.githubusercontent.com/assets/6097762/22251758/fffc087e-e25c-11e6-80be-17be231230de.png)
Here it is filtered
![image](https://cloud.githubusercontent.com/assets/6097762/22251785/13aaaf88-e25d-11e6-867d-a54b078c86d5.png)
