### PR TITLE
Allow user specific ALV variant in SALV converter

### DIFF
--- a/src/zcl_excel_converter_salv_table.clas.abap
+++ b/src/zcl_excel_converter_salv_table.clas.abap
@@ -125,7 +125,7 @@ method LOAD_DATA.
         i_tabname                   = '1'
 *       I_TABNAME_SLAVE             =
         i_dialog                    = ' '
-*       I_USER_SPECIFIC             = ' '
+        I_USER_SPECIFIC             = 'X'
 *       I_DEFAULT                   = 'X'
 *       I_NO_REPTEXT_OPTIMIZE       =
 *       I_VIA_GRID                  =


### PR DESCRIPTION
Same problem is in standart CL_SALV_TABLE~TO_XML method (from which this converter was probably inspired).