### PR TITLE
Performance improvement for GET_ROW method

### DIFF
--- a/src/zcl_excel_rows.clas.abap
+++ b/src/zcl_excel_rows.clas.abap
@@ -3,45 +3,54 @@
 *----------------------------------------------------------------------*
 *
 *----------------------------------------------------------------------*
-class ZCL_EXCEL_ROWS definition
-  public
-  final
-  create public .
+CLASS ZCL_EXCEL_ROWS DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
 
 *"* public components of class ZCL_EXCEL_ROWS
 *"* do not include other source files here!!!
 *"* protected components of class ZABAP_EXCEL_WORKSHEETS
 *"* do not include other source files here!!!
-public section.
+  PUBLIC SECTION.
+    TYPES:
+      BEGIN OF T_ROWS,
+        ROW_INDEX TYPE INT4,
+        ROW       TYPE REF TO ZCL_EXCEL_ROW,
+      END OF T_ROWS.
 
-  methods ADD
-    importing
-      !IO_ROW type ref to ZCL_EXCEL_ROW .
-  methods CLEAR .
-  methods CONSTRUCTOR .
-  methods GET
-    importing
-      !IP_INDEX type I
-    returning
-      value(EO_ROW) type ref to ZCL_EXCEL_ROW .
-  methods GET_ITERATOR
-    returning
-      value(EO_ITERATOR) type ref to CL_OBJECT_COLLECTION_ITERATOR .
-  methods IS_EMPTY
-    returning
-      value(IS_EMPTY) type FLAG .
-  methods REMOVE
-    importing
-      !IO_ROW type ref to ZCL_EXCEL_ROW .
-  methods SIZE
-    returning
-      value(EP_SIZE) type I .
+    DATA:
+          DT_ROWS TYPE HASHED TABLE OF T_ROWS WITH UNIQUE KEY ROW_INDEX.
+
+    METHODS ADD
+      IMPORTING
+        !IO_ROW TYPE REF TO ZCL_EXCEL_ROW .
+    METHODS CLEAR .
+    METHODS CONSTRUCTOR .
+    METHODS GET
+      IMPORTING
+        !IP_INDEX     TYPE I
+      RETURNING
+        VALUE(EO_ROW) TYPE REF TO ZCL_EXCEL_ROW .
+    METHODS GET_ITERATOR
+      RETURNING
+        VALUE(EO_ITERATOR) TYPE REF TO CL_OBJECT_COLLECTION_ITERATOR .
+    METHODS IS_EMPTY
+      RETURNING
+        VALUE(IS_EMPTY) TYPE FLAG .
+    METHODS REMOVE
+      IMPORTING
+        !IO_ROW TYPE REF TO ZCL_EXCEL_ROW .
+    METHODS SIZE
+      RETURNING
+        VALUE(EP_SIZE) TYPE I .
   PROTECTED SECTION.
 *"* private components of class ZABAP_EXCEL_RANGES
 *"* do not include other source files here!!!
   PRIVATE SECTION.
 
-    DATA rows TYPE REF TO cl_object_collection .
+    DATA ROWS TYPE REF TO CL_OBJECT_COLLECTION .
 ENDCLASS.
 
 
@@ -49,44 +58,118 @@ ENDCLASS.
 CLASS ZCL_EXCEL_ROWS IMPLEMENTATION.
 
 
-  METHOD add.
-    rows->add( io_row ).
+* <SIGNATURE>---------------------------------------------------------------------------------------+
+* | Instance Public Method ZCL_EXCEL_ROWS->ADD
+* +-------------------------------------------------------------------------------------------------+
+* | [--->] IO_ROW                         TYPE REF TO ZCL_EXCEL_ROW
+* +--------------------------------------------------------------------------------------</SIGNATURE>
+  METHOD ADD.
+*    IF SY-UNAME = 'BILEN'.
+    DATA:
+          LS_ROW TYPE T_ROWS.
+    LS_ROW-ROW_INDEX = IO_ROW->GET_ROW_INDEX( ).
+    LS_ROW-ROW = IO_ROW.
+    INSERT LS_ROW INTO TABLE DT_ROWS.
+*
+*    ELSE.
+*      ROWS->ADD( IO_ROW ).
+*
+*    ENDIF.
+
   ENDMETHOD.                    "ADD
 
 
-  METHOD clear.
-    rows->clear( ).
+* <SIGNATURE>---------------------------------------------------------------------------------------+
+* | Instance Public Method ZCL_EXCEL_ROWS->CLEAR
+* +-------------------------------------------------------------------------------------------------+
+* +--------------------------------------------------------------------------------------</SIGNATURE>
+  METHOD CLEAR.
+*    ROWS->CLEAR( ).
+    CLEAR DT_ROWS[].
+
   ENDMETHOD.                    "CLEAR
 
 
-  METHOD constructor.
+* <SIGNATURE>---------------------------------------------------------------------------------------+
+* | Instance Public Method ZCL_EXCEL_ROWS->CONSTRUCTOR
+* +-------------------------------------------------------------------------------------------------+
+* +--------------------------------------------------------------------------------------</SIGNATURE>
+  METHOD CONSTRUCTOR.
 
-    CREATE OBJECT rows.
+    CREATE OBJECT ROWS.
 
   ENDMETHOD.                    "CONSTRUCTOR
 
 
-  METHOD get.
-    eo_row ?= rows->if_object_collection~get( ip_index ).
+* <SIGNATURE>---------------------------------------------------------------------------------------+
+* | Instance Public Method ZCL_EXCEL_ROWS->GET
+* +-------------------------------------------------------------------------------------------------+
+* | [--->] IP_INDEX                       TYPE        I
+* | [<-()] EO_ROW                         TYPE REF TO ZCL_EXCEL_ROW
+* +--------------------------------------------------------------------------------------</SIGNATURE>
+  METHOD GET.
+*    IF SY-UNAME = 'BILEN'.
+    READ TABLE DT_ROWS ASSIGNING FIELD-SYMBOL(<LS_ROW>) WITH TABLE KEY ROW_INDEX = IP_INDEX.
+    IF SY-SUBRC = 0.
+      EO_ROW ?= <LS_ROW>-ROW.
+    ENDIF.
+*    ELSE.
+*      EO_ROW ?= ROWS->IF_OBJECT_COLLECTION~GET( IP_INDEX ).
+*
+*    ENDIF.
   ENDMETHOD.                    "GET
 
 
-  METHOD get_iterator.
-    eo_iterator ?= rows->if_object_collection~get_iterator( ).
+* <SIGNATURE>---------------------------------------------------------------------------------------+
+* | Instance Public Method ZCL_EXCEL_ROWS->GET_ITERATOR
+* +-------------------------------------------------------------------------------------------------+
+* | [<-()] EO_ITERATOR                    TYPE REF TO CL_OBJECT_COLLECTION_ITERATOR
+* +--------------------------------------------------------------------------------------</SIGNATURE>
+  METHOD GET_ITERATOR.
+    EO_ITERATOR ?= ROWS->IF_OBJECT_COLLECTION~GET_ITERATOR( ).
   ENDMETHOD.                    "GET_ITERATOR
 
 
-  METHOD is_empty.
-    is_empty = rows->if_object_collection~is_empty( ).
+* <SIGNATURE>---------------------------------------------------------------------------------------+
+* | Instance Public Method ZCL_EXCEL_ROWS->IS_EMPTY
+* +-------------------------------------------------------------------------------------------------+
+* | [<-()] IS_EMPTY                       TYPE        FLAG
+* +--------------------------------------------------------------------------------------</SIGNATURE>
+  METHOD IS_EMPTY.
+    DATA(LV_LINES) = LINES( DT_ROWS ).
+
+    IF LV_LINES = 0.
+      IS_EMPTY = 'X'.
+    ELSE.
+      IS_EMPTY = ' '.
+    ENDIF.
+*    IS_EMPTY = ROWS->IF_OBJECT_COLLECTION~IS_EMPTY( ).
   ENDMETHOD.                    "IS_EMPTY
 
 
-  METHOD remove.
-    rows->remove( io_row ).
+* <SIGNATURE>---------------------------------------------------------------------------------------+
+* | Instance Public Method ZCL_EXCEL_ROWS->REMOVE
+* +-------------------------------------------------------------------------------------------------+
+* | [--->] IO_ROW                         TYPE REF TO ZCL_EXCEL_ROW
+* +--------------------------------------------------------------------------------------</SIGNATURE>
+  METHOD REMOVE.
+*    ROWS->REMOVE( IO_ROW ).
+    DELETE DT_ROWS WHERE ROW_INDEX = IO_ROW->GET_ROW_INDEX( ).
   ENDMETHOD.                    "REMOVE
 
 
-  METHOD size.
-    ep_size = rows->if_object_collection~size( ).
+* <SIGNATURE>---------------------------------------------------------------------------------------+
+* | Instance Public Method ZCL_EXCEL_ROWS->SIZE
+* +-------------------------------------------------------------------------------------------------+
+* | [<-()] EP_SIZE                        TYPE        I
+* +--------------------------------------------------------------------------------------</SIGNATURE>
+  METHOD SIZE.
+*    IF sy-uname = 'BILEN'.
+    EP_SIZE = LINES( DT_ROWS )..
+*
+*    else.
+*    EP_SIZE = ROWS->IF_OBJECT_COLLECTION~SIZE( ).
+*
+*    ENDIF.
   ENDMETHOD.                    "SIZE
 ENDCLASS.

--- a/src/zcl_excel_rows.clas.abap
+++ b/src/zcl_excel_rows.clas.abap
@@ -128,9 +128,9 @@ CLASS ZCL_EXCEL_ROWS IMPLEMENTATION.
     DATA(LV_LINES) = LINES( DT_ROWS ).
 
     IF LV_LINES = 0.
-      IS_EMPTY = 'X'.
+      IS_EMPTY = abap_true.
     ELSE.
-      IS_EMPTY = ' '.
+      IS_EMPTY = abap_false.
     ENDIF.
   ENDMETHOD.                    "IS_EMPTY
 

--- a/src/zcl_excel_rows.clas.abap
+++ b/src/zcl_excel_rows.clas.abap
@@ -15,7 +15,7 @@ CLASS ZCL_EXCEL_ROWS DEFINITION
 *"* do not include other source files here!!!
   PUBLIC SECTION.
     TYPES:
-      BEGIN OF T_ROWS,
+      BEGIN OF T_ROWS, " performance improvement #527
         ROW_INDEX TYPE INT4,
         ROW       TYPE REF TO ZCL_EXCEL_ROW,
       END OF T_ROWS.
@@ -64,17 +64,12 @@ CLASS ZCL_EXCEL_ROWS IMPLEMENTATION.
 * | [--->] IO_ROW                         TYPE REF TO ZCL_EXCEL_ROW
 * +--------------------------------------------------------------------------------------</SIGNATURE>
   METHOD ADD.
-*    IF SY-UNAME = 'BILEN'.
+
     DATA:
           LS_ROW TYPE T_ROWS.
     LS_ROW-ROW_INDEX = IO_ROW->GET_ROW_INDEX( ).
     LS_ROW-ROW = IO_ROW.
     INSERT LS_ROW INTO TABLE DT_ROWS.
-*
-*    ELSE.
-*      ROWS->ADD( IO_ROW ).
-*
-*    ENDIF.
 
   ENDMETHOD.                    "ADD
 
@@ -84,7 +79,6 @@ CLASS ZCL_EXCEL_ROWS IMPLEMENTATION.
 * +-------------------------------------------------------------------------------------------------+
 * +--------------------------------------------------------------------------------------</SIGNATURE>
   METHOD CLEAR.
-*    ROWS->CLEAR( ).
     CLEAR DT_ROWS[].
 
   ENDMETHOD.                    "CLEAR
@@ -108,15 +102,10 @@ CLASS ZCL_EXCEL_ROWS IMPLEMENTATION.
 * | [<-()] EO_ROW                         TYPE REF TO ZCL_EXCEL_ROW
 * +--------------------------------------------------------------------------------------</SIGNATURE>
   METHOD GET.
-*    IF SY-UNAME = 'BILEN'.
     READ TABLE DT_ROWS ASSIGNING FIELD-SYMBOL(<LS_ROW>) WITH TABLE KEY ROW_INDEX = IP_INDEX.
     IF SY-SUBRC = 0.
       EO_ROW ?= <LS_ROW>-ROW.
     ENDIF.
-*    ELSE.
-*      EO_ROW ?= ROWS->IF_OBJECT_COLLECTION~GET( IP_INDEX ).
-*
-*    ENDIF.
   ENDMETHOD.                    "GET
 
 
@@ -143,7 +132,6 @@ CLASS ZCL_EXCEL_ROWS IMPLEMENTATION.
     ELSE.
       IS_EMPTY = ' '.
     ENDIF.
-*    IS_EMPTY = ROWS->IF_OBJECT_COLLECTION~IS_EMPTY( ).
   ENDMETHOD.                    "IS_EMPTY
 
 
@@ -153,7 +141,6 @@ CLASS ZCL_EXCEL_ROWS IMPLEMENTATION.
 * | [--->] IO_ROW                         TYPE REF TO ZCL_EXCEL_ROW
 * +--------------------------------------------------------------------------------------</SIGNATURE>
   METHOD REMOVE.
-*    ROWS->REMOVE( IO_ROW ).
     DELETE DT_ROWS WHERE ROW_INDEX = IO_ROW->GET_ROW_INDEX( ).
   ENDMETHOD.                    "REMOVE
 
@@ -164,12 +151,6 @@ CLASS ZCL_EXCEL_ROWS IMPLEMENTATION.
 * | [<-()] EP_SIZE                        TYPE        I
 * +--------------------------------------------------------------------------------------</SIGNATURE>
   METHOD SIZE.
-*    IF sy-uname = 'BILEN'.
     EP_SIZE = LINES( DT_ROWS )..
-*
-*    else.
-*    EP_SIZE = ROWS->IF_OBJECT_COLLECTION~SIZE( ).
-*
-*    ENDIF.
   ENDMETHOD.                    "SIZE
 ENDCLASS.

--- a/src/zcl_excel_rows.clas.abap
+++ b/src/zcl_excel_rows.clas.abap
@@ -21,7 +21,7 @@ CLASS ZCL_EXCEL_ROWS DEFINITION
       END OF T_ROWS.
 
     DATA:
-          DT_ROWS TYPE HASHED TABLE OF T_ROWS WITH UNIQUE KEY ROW_INDEX.
+          DT_ROWS TYPE HASHED TABLE OF T_ROWS WITH UNIQUE KEY ROW_INDEX READ-ONLY.
 
     METHODS ADD
       IMPORTING
@@ -33,9 +33,6 @@ CLASS ZCL_EXCEL_ROWS DEFINITION
         !IP_INDEX     TYPE I
       RETURNING
         VALUE(EO_ROW) TYPE REF TO ZCL_EXCEL_ROW .
-    METHODS GET_ITERATOR
-      RETURNING
-        VALUE(EO_ITERATOR) TYPE REF TO CL_OBJECT_COLLECTION_ITERATOR .
     METHODS IS_EMPTY
       RETURNING
         VALUE(IS_EMPTY) TYPE FLAG .
@@ -107,16 +104,6 @@ CLASS ZCL_EXCEL_ROWS IMPLEMENTATION.
       EO_ROW ?= <LS_ROW>-ROW.
     ENDIF.
   ENDMETHOD.                    "GET
-
-
-* <SIGNATURE>---------------------------------------------------------------------------------------+
-* | Instance Public Method ZCL_EXCEL_ROWS->GET_ITERATOR
-* +-------------------------------------------------------------------------------------------------+
-* | [<-()] EO_ITERATOR                    TYPE REF TO CL_OBJECT_COLLECTION_ITERATOR
-* +--------------------------------------------------------------------------------------</SIGNATURE>
-  METHOD GET_ITERATOR.
-    EO_ITERATOR ?= ROWS->IF_OBJECT_COLLECTION~GET_ITERATOR( ).
-  ENDMETHOD.                    "GET_ITERATOR
 
 
 * <SIGNATURE>---------------------------------------------------------------------------------------+

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -4098,20 +4098,14 @@ method GET_RANGES_ITERATOR.
 
 METHOD get_row.
 
-  DATA: lo_row_iterator TYPE REF TO cl_object_collection_iterator,
-        lo_row          TYPE REF TO zcl_excel_row.
+* performance improvement for issue #527
+  READ TABLE ROWS->DT_ROWS ASSIGNING FIELD-SYMBOL(<LS_ROW>) WITH TABLE KEY ROW_INDEX = IP_ROW.
+  IF SY-SUBRC = 0.
+    EO_ROW = <LS_ROW>-ROW.
+  ENDIF.
 
-  lo_row_iterator = me->get_rows_iterator( ).
-  WHILE lo_row_iterator->has_next( ) = abap_true.
-    lo_row ?= lo_row_iterator->get_next( ).
-    IF lo_row->get_row_index( ) = ip_row.
-      eo_row = lo_row.
-      EXIT.
-    ENDIF.
-  ENDWHILE.
-
-  IF eo_row IS NOT BOUND.
-    eo_row = me->add_new_row( ip_row ).
+  IF EO_ROW IS NOT BOUND.
+    EO_ROW = ME->ADD_NEW_ROW( IP_ROW ).
   ENDIF.
 
 ENDMETHOD.


### PR DESCRIPTION
Issue #527 has been fixed after updating ZCL_EXCEL_ROWS class by removing object iterator and introducing hash table.  ZCL_EXCEL_WORKSHEET->GET_ROW method has been updated accordingly based on new structure to read directly from hash table.
Before : 
![image](https://user-images.githubusercontent.com/17006134/37655798-366b1250-2c81-11e8-8f37-bce965938488.png)

And after:
![image](https://user-images.githubusercontent.com/17006134/37655806-3d8f3ee4-2c81-11e8-98e7-26712981c943.png)
