### PR TITLE
modern style exception raise

### DIFF
--- a/src/zcl_excel.clas.abap
+++ b/src/zcl_excel.clas.abap
@@ -56,7 +56,7 @@ public section.
       ZCX_EXCEL .
   methods DELETE_WORKSHEET_BY_NAME
     importing
-      !IV_TITLE type CLIKE 
+      !IV_TITLE type CLIKE
     raising
       ZCX_EXCEL .
   methods GET_ACTIVE_SHEET_INDEX
@@ -281,13 +281,13 @@ method CONSTRUCTOR.
 
   me->zif_excel_book_protection~initialize( ).
   me->zif_excel_book_properties~initialize( ).
-  
+
   try.
       me->add_new_worksheet( ).
     catch zcx_excel. " suppress syntax check error
       assert 1 = 2.  " some error processing anyway
   endtry.
-  
+
   me->add_new_style( ). " Standard style
   lo_style = me->add_new_style( ). " Standard style with fill gray125
   lo_style->fill->filltype = zcl_excel_style_fill=>c_fill_pattern_gray125.
@@ -306,9 +306,7 @@ METHOD delete_worksheet.
     lo_worksheet = me->get_worksheet_by_index( 1 ).
     IF lo_worksheet = io_worksheet.
       lv_errormessage = 'Deleting last remaining worksheet is not allowed'(002).
-      RAISE EXCEPTION TYPE zcx_excel
-        EXPORTING
-          error = lv_errormessage.
+      zcx_excel=>raise_text( lv_errormessage ).
     ENDIF.
   ENDIF.
 
@@ -325,9 +323,7 @@ METHOD delete_worksheet_by_index.
   lo_worksheet = me->get_worksheet_by_index( iv_index ).
   IF lo_worksheet IS NOT BOUND.
     lv_errormessage = 'Worksheet not existing'(001).
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error = lv_errormessage.
+    zcx_excel=>raise_text( lv_errormessage ).
   ENDIF.
   me->delete_worksheet( lo_worksheet ).
 
@@ -342,9 +338,7 @@ METHOD delete_worksheet_by_name.
   lo_worksheet = me->get_worksheet_by_name( iv_title ).
   IF lo_worksheet IS NOT BOUND.
     lv_errormessage = 'Worksheet not existing'(001).
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error = lv_errormessage.
+    zcx_excel=>raise_text( lv_errormessage ).
   ENDIF.
   me->delete_worksheet( lo_worksheet ).
 
@@ -481,9 +475,7 @@ method GET_STYLE_INDEX_IN_STYLES.
   ENDWHILE.
 
   IF ep_index IS INITIAL.
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error = 'Index not found'.
+    zcx_excel=>raise_text( 'Index not found' ).
   else.
     SUBTRACT 1 from ep_index.  " In excel list starts with "0"
   ENDIF.
@@ -495,9 +487,7 @@ METHOD get_style_to_guid.
   " # issue 139
   READ TABLE me->t_stylemapping2 INTO ep_stylemapping WITH TABLE KEY guid = ip_guid.
   IF sy-subrc <> 0.
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error = 'GUID not found'.
+    zcx_excel=>raise_text( 'GUID not found' ).
   ENDIF.
 
   IF ep_stylemapping-dynamic_style_guid IS NOT INITIAL.
@@ -576,9 +566,7 @@ METHOD set_active_sheet_index.
   lo_worksheet = me->get_worksheet_by_index( i_active_worksheet ).
   IF lo_worksheet IS NOT BOUND.
     lv_errormessage = 'Worksheet not existing'(001).
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error = lv_errormessage.
+    zcx_excel=>raise_text( lv_errormessage ).
   ENDIF.
 
   me->worksheets->active_worksheet = i_active_worksheet.

--- a/src/zcl_excel_autofilter.clas.abap
+++ b/src/zcl_excel_autofilter.clas.abap
@@ -99,7 +99,7 @@ private section.
   data WORKSHEET type ref to ZCL_EXCEL_WORKSHEET .
   data MT_FILTERS type TT_FILTERS .
 
-  methods VALIDATE_AREA 
+  methods VALIDATE_AREA
     raising
       ZCX_EXCEL .
 ENDCLASS.

--- a/src/zcl_excel_column.clas.abap
+++ b/src/zcl_excel_column.clas.abap
@@ -185,9 +185,7 @@ method SET_COLUMN_STYLE_BY_GUID.
   DATA: stylemapping TYPE zexcel_s_stylemapping.
 
   IF me->excel IS NOT BOUND.
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error = 'Internal error - reference to ZCL_EXCEL not bound'.
+    zcx_excel=>raise_text( 'Internal error - reference to ZCL_EXCEL not bound' ).
   ENDIF.
   TRY.
       stylemapping = me->excel->get_style_to_guid( ip_style_guid ).
@@ -216,9 +214,7 @@ METHOD set_width.
       me->width = ip_width.
       io_column = me.
     CATCH cx_sy_conversion_no_number.
-      RAISE EXCEPTION TYPE zcx_excel
-        EXPORTING
-          error = 'Unable to interpret width as number'.
+      zcx_excel=>raise_text( 'Unable to interpret width as number' ).
   ENDTRY.
 ENDMETHOD.
 

--- a/src/zcl_excel_common.clas.abap
+++ b/src/zcl_excel_common.clas.abap
@@ -405,9 +405,7 @@ METHOD convert_column2alpha.
 *--------------------------------------------------------------------*
   IF   lv_column > 16384
     OR lv_column < 1.
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error = 'Index out of bounds'.
+    zcx_excel=>raise_text( 'Index out of bounds' ).
   ENDIF.
 
 *--------------------------------------------------------------------*
@@ -488,13 +486,8 @@ METHOD convert_column2int.
   CONDENSE lv_column_c NO-GAPS.
   IF lv_column_c EQ ''.
 *    lv_errormessage = 'Unable to interpret input as column'(003).
-*    RAISE EXCEPTION TYPE zcx_excel
-*      EXPORTING
-*        error = lv_errormessage.
     MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        syst_at_raise = syst.
+    zcx_excel=>raise_symsg( ).
   ENDIF.
 
 *--------------------------------------------------------------------*
@@ -520,9 +513,7 @@ METHOD convert_column2int.
 *--------------------------------------------------------------------*
         IF ep_column > 16384 OR ep_column < 1.
           lv_errormessage = 'Index out of bounds'(004).
-          RAISE EXCEPTION TYPE zcx_excel
-            EXPORTING
-              error = lv_errormessage.
+          zcx_excel=>raise_text( lv_errormessage ).
         ENDIF.
         EXIT.
       ENDIF.
@@ -536,13 +527,8 @@ METHOD convert_column2int.
   lv_column_s = lv_column_c.
   IF lv_column_s CN sy-abcde.
 *    lv_errormessage = 'Unable to interpret input as column'(003).
-*    RAISE EXCEPTION TYPE zcx_excel
-*      EXPORTING
-*        error = lv_errormessage.
     MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        syst_at_raise = syst.
+    zcx_excel=>raise_symsg( ).
   ENDIF.
 
   DO 1 TIMES. "Because of using CHECK
@@ -556,13 +542,8 @@ METHOD convert_column2int.
     lv_modulo = cl_abap_conv_out_ce=>uccpi( lv_column+0(1) ) MOD zcl_excel_common=>c_excel_col_module.
     IF lv_modulo < 1 OR lv_modulo > 26.
 *    lv_errormessage = 'Unable to interpret input as column'(003).
-*    RAISE EXCEPTION TYPE zcx_excel
-*      EXPORTING
-*        error = lv_errormessage.
       MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
-      RAISE EXCEPTION TYPE zcx_excel
-        EXPORTING
-          syst_at_raise = syst.
+      zcx_excel=>raise_symsg( ).
     ENDIF.
     ep_column = lv_modulo.                    " Leftmost digit
 
@@ -573,13 +554,8 @@ METHOD convert_column2int.
     lv_modulo = cl_abap_conv_out_ce=>uccpi( lv_column+1(1) ) MOD zcl_excel_common=>c_excel_col_module.
     IF lv_modulo < 1 OR lv_modulo > 26.
 *    lv_errormessage = 'Unable to interpret input as column'(003).
-*    RAISE EXCEPTION TYPE zcx_excel
-*      EXPORTING
-*        error = lv_errormessage.
       MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
-      RAISE EXCEPTION TYPE zcx_excel
-        EXPORTING
-          syst_at_raise = syst.
+      zcx_excel=>raise_symsg( ).
     ENDIF.
     ep_column = 26 * ep_column + lv_modulo.   " if second digit is present first digit is for 26^1
 
@@ -590,13 +566,8 @@ METHOD convert_column2int.
     lv_modulo = cl_abap_conv_out_ce=>uccpi( lv_column+2(1) ) MOD zcl_excel_common=>c_excel_col_module.
     IF lv_modulo < 1 OR lv_modulo > 26.
 *    lv_errormessage = 'Unable to interpret input as column'(003).
-*    RAISE EXCEPTION TYPE zcx_excel
-*      EXPORTING
-*        error = lv_errormessage.
       MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
-      RAISE EXCEPTION TYPE zcx_excel
-        EXPORTING
-          syst_at_raise = syst.
+      zcx_excel=>raise_symsg( ).
     ENDIF.
     ep_column = 26 * ep_column + lv_modulo.   " if third digit is present first digit is for 26^2 and second digit for 26^1
   ENDDO.
@@ -606,9 +577,7 @@ METHOD convert_column2int.
 *--------------------------------------------------------------------*
   IF ep_column > 16384 OR ep_column < 1.
     lv_errormessage = 'Index out of bounds'(004).
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error = lv_errormessage.
+    zcx_excel=>raise_text( lv_errormessage ).
   ENDIF.
 
 *--------------------------------------------------------------------*
@@ -695,9 +664,7 @@ method CONVERT_RANGE2COLUMN_A_ROW.
       SHIFT lv_range LEFT BY sy-fdpos PLACES.
     ELSE.
       lv_errormessage = 'Invalid range'(001).
-      RAISE EXCEPTION TYPE zcx_excel
-        EXPORTING
-          error    = lv_errormessage.
+      zcx_excel=>raise_text( lv_errormessage ).
     ENDIF.
 
   ELSEIF i_range CS '!'.                                " c) sheetname existing - does not start with '
@@ -917,9 +884,7 @@ method EXCEL_STRING_TO_DATE.
         ep_value = ep_value + 1.
       ENDIF.
     CATCH cx_sy_conversion_error.
-      RAISE EXCEPTION TYPE zcx_excel
-        EXPORTING
-          error = 'Index out of bounds'.
+      zcx_excel=>raise_text( 'Index out of bounds' ).
   ENDTRY.
 endmethod.
 
@@ -947,9 +912,7 @@ method EXCEL_STRING_TO_TIME.
       ep_value = lv_seconds_in_day.
 
     CATCH cx_sy_conversion_error.
-      RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error = 'Unable to interpret time'.
+      zcx_excel=>raise_text( 'Unable to interpret time' ).
   ENDTRY.
 endmethod.
 
@@ -1381,9 +1344,7 @@ METHOD shift_formula.
             MOVE: iv_reference_formula+lv_offset1(lv_tlen) TO lv_ref_cell_addr. "Ref cell address
           CATCH cx_root.
             lv_errormessage = 'Internal error in Class ZCL_EXCEL_COMMON Method SHIFT_FORMULA Spot 1 '.  " Change to messageclass if possible
-            RAISE EXCEPTION TYPE zcx_excel
-              EXPORTING
-                error    = lv_errormessage.
+            zcx_excel=>raise_text( lv_errormessage ).
         ENDTRY.
 
 *--------------------------------------------------------------------*
@@ -1720,9 +1681,7 @@ method UNESCAPE_STRING.
   REPLACE REGEX `^'(.*)'$` IN ev_unescaped_string WITH '$1'.
   IF sy-subrc <> 0.
     lv_errormessage = 'Input not properly escaped - &'(002).
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error    = lv_errormessage.
+    zcx_excel=>raise_text( lv_errormessage ).
   ENDIF.
 
 *--------------------------------------------------------------------*
@@ -1731,9 +1690,7 @@ method UNESCAPE_STRING.
   FIND REGEX lcv_regex IN ev_unescaped_string.
   IF sy-subrc = 0.
     lv_errormessage = 'Input not properly escaped - &'(002).
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error    = lv_errormessage.
+    zcx_excel=>raise_text( lv_errormessage ).
   ENDIF.
 
 *--------------------------------------------------------------------*

--- a/src/zcl_excel_drawing.clas.abap
+++ b/src/zcl_excel_drawing.clas.abap
@@ -98,7 +98,7 @@ public section.
       !IP_FROM_ROW type ZEXCEL_CELL_ROW
       !IP_FROM_COL type ZEXCEL_CELL_COLUMN_ALPHA
       !IP_ROWOFF type INT4 optional
-      !IP_COLOFF type INT4 optional 
+      !IP_COLOFF type INT4 optional
     raising
       ZCX_EXCEL .
   methods SET_POSITION2

--- a/src/zcl_excel_legacy_palette.clas.abap
+++ b/src/zcl_excel_legacy_palette.clas.abap
@@ -24,7 +24,7 @@ public section.
   methods SET_COLOR
     importing
       !IP_INDEX type I
-      !IP_COLOR type ZEXCEL_STYLE_COLOR_ARGB 
+      !IP_COLOR type ZEXCEL_STYLE_COLOR_ARGB
     raising
       ZCX_EXCEL .
 protected section.
@@ -127,9 +127,7 @@ method GET_COLOR.
   lv_index = ip_index + 1.
   READ TABLE colors INTO ep_color INDEX lv_index.
   IF sy-subrc <> 0.
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error = 'Invalid color index'.
+    zcx_excel=>raise_text( 'Invalid color index' ).
   ENDIF.
   endmethod.
 
@@ -152,9 +150,7 @@ method SET_COLOR.
   lv_index = ip_index + 1.
   READ TABLE colors ASSIGNING <lv_color> INDEX lv_index.
   IF sy-subrc <> 0.
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error = 'Invalid color index'.
+    zcx_excel=>raise_text( 'Invalid color index' ).
   ENDIF.
 
   IF <lv_color> <> ip_color.

--- a/src/zcl_excel_reader_2007.clas.abap
+++ b/src/zcl_excel_reader_2007.clas.abap
@@ -270,7 +270,7 @@ private section.
     importing
       !I_FILENAME type CSEQUENCE
     returning
-      value(R_EXCEL_DATA) type XSTRING 
+      value(R_EXCEL_DATA) type XSTRING
     raising
       ZCX_EXCEL.
   methods READ_FROM_LOCAL_FILE
@@ -3567,9 +3567,7 @@ METHOD read_from_applserver.
     OPEN DATASET lv_filename FOR INPUT IN BINARY MODE.
     IF sy-subrc <> 0.
       lv_errormessage = 'A problem occured when reading the file'(001).
-      RAISE EXCEPTION TYPE zcx_excel
-        EXPORTING
-          error = lv_errormessage.
+      zcx_excel=>raise_text( lv_errormessage ).
     ENDIF.
     WHILE sy-subrc = 0.
 
@@ -3631,9 +3629,7 @@ METHOD read_from_local_file.
                                             OTHERS                  = 19 ).
     IF sy-subrc <> 0.
       lv_errormessage = 'A problem occured when reading the file'(001).
-      RAISE EXCEPTION TYPE zcx_excel
-        EXPORTING
-          error = lv_errormessage.
+      zcx_excel=>raise_text( lv_errormessage ).
     ENDIF.
 
 *--------------------------------------------------------------------*

--- a/src/zcl_excel_reader_huge_file.clas.abap
+++ b/src/zcl_excel_reader_huge_file.clas.abap
@@ -211,9 +211,7 @@ method LOAD_WORKSHEET.
                            io_worksheet = io_worksheet ).
 
     catch lcx_not_found into lx_not_found.
-      raise exception type zcx_excel
-        exporting
-          error = lx_not_found->error.
+      zcx_excel=>raise_text( lx_not_found->error ).
   endtry.
 endmethod.
 

--- a/src/zcl_excel_row.clas.abap
+++ b/src/zcl_excel_row.clas.abap
@@ -190,9 +190,7 @@ method SET_OUTLINE_LEVEL.
   IF   ip_outline_level < 0
     OR ip_outline_level > 7.
 
-    RAISE EXCEPTION TYPE zcx_excel
-      EXPORTING
-        error = 'Outline level must range between 0 and 7.'.
+    zcx_excel=>raise_text( 'Outline level must range between 0 and 7.' ).
 
   ENDIF.
   me->outline_level = ip_outline_level.
@@ -203,9 +201,7 @@ method SET_ROW_HEIGHT.
   TRY.
       me->row_height = ip_row_height.
     CATCH cx_sy_conversion_no_number.
-      RAISE EXCEPTION TYPE zcx_excel
-        EXPORTING
-          error = 'Unable to interpret ip_row_height as number'.
+      zcx_excel=>raise_text( 'Unable to interpret ip_row_height as number' ).
   ENDTRY.
   endmethod.
 

--- a/src/zcl_excel_table.clas.abap
+++ b/src/zcl_excel_table.clas.abap
@@ -261,9 +261,7 @@ method GET_TOTALS_FORMULA.
       RETURN.
 
     WHEN OTHERS.
-      RAISE EXCEPTION TYPE zcx_excel
-    EXPORTING
-      error = 'Invalid totals formula. See ZCL_ for possible values'.
+      zcx_excel=>raise_text( 'Invalid totals formula. See ZCL_ for possible values' ).
   ENDCASE.
 
   CONCATENATE 'SUBTOTAL(' lv_function_id ',[' ip_column '])' INTO ep_formula.

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -224,7 +224,7 @@ class ZCL_EXCEL_WORKSHEET definition
     methods DELETE_MERGE
       importing
         !IP_CELL_COLUMN type SIMPLE optional
-        !IP_CELL_ROW    type ZEXCEL_CELL_ROW optional 
+        !IP_CELL_ROW    type ZEXCEL_CELL_ROW optional
       raising
         ZCX_EXCEL .
     methods DELETE_ROW_OUTLINE
@@ -2817,9 +2817,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
                (  LV_MAXCOL     ge ZCL_EXCEL_COMMON=>CONVERT_COLUMN2INT( LO_CURTABLE->SETTINGS-TOP_LEFT_COLUMN ) and LV_MAXCOL     le ZCL_EXCEL_COMMON=>CONVERT_COLUMN2INT( LO_CURTABLE->SETTINGS-BOTTOM_RIGHT_COLUMN ) )
           ).
         LV_ERRORMESSAGE = 'Table overlaps with previously bound table and will not be added to worksheet.'(400).
-        raise exception type ZCX_EXCEL
-          exporting
-            ERROR = LV_ERRORMESSAGE.
+        zcx_excel=>raise_text( lv_errormessage ).
       endif.
 
     endwhile.
@@ -3395,9 +3393,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
 *  move_supplied_multistyles: complete.
     if IP_COMPLETE is supplied.
       if IP_XCOMPLETE is not supplied.
-        raise exception type ZCX_EXCEL
-          exporting
-            ERROR = 'Complete styleinfo has to be supplied with corresponding X-field'.
+        zcx_excel=>raise_text( 'Complete styleinfo has to be supplied with corresponding X-field' ).
       endif.
       move-corresponding IP_COMPLETE  to COMPLETE_STYLE.
       move-corresponding IP_XCOMPLETE to COMPLETE_STYLEX.
@@ -3727,9 +3723,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
     delete ME->MT_ROW_OUTLINES where ROW_FROM = IV_ROW_FROM
                                  and ROW_TO   = IV_ROW_TO.
     if SY-SUBRC <> 0.  " didn't find outline that was to be deleted
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = 'Row outline to be deleted does not exist'.
+      zcx_excel=>raise_text( 'Row outline to be deleted does not exist' ).
     endif.
 
   endmethod.
@@ -3738,21 +3732,15 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
   method FREEZE_PANES.
 
     if IP_NUM_COLUMNS is not supplied and IP_NUM_ROWS is not supplied.
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = 'Pleas provide number of rows and/or columns to freeze'.
+      zcx_excel=>raise_text( 'Pleas provide number of rows and/or columns to freeze' ).
     endif.
 
     if IP_NUM_COLUMNS is supplied and IP_NUM_COLUMNS <= 0.
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = 'Number of columns to freeze should be positive'.
+      zcx_excel=>raise_text( 'Number of columns to freeze should be positive' ).
     endif.
 
     if IP_NUM_ROWS is supplied and IP_NUM_ROWS <= 0.
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = 'Number of rows to freeze should be positive'.
+      zcx_excel=>raise_text( 'Number of rows to freeze should be positive' ).
     endif.
 
     FREEZE_PANE_CELL_COLUMN = IP_NUM_COLUMNS + 1.
@@ -4189,18 +4177,14 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
         if SY-SUBRC <> 0 or <LS_LINE> is not assigned.
 
           LV_ERRORMESSAGE = 'Error at inserting new Line to internal Table'(002).
-          raise exception type ZCX_EXCEL
-            exporting
-              ERROR = LV_ERRORMESSAGE.
+          zcx_excel=>raise_text( lv_errormessage ).
 
         else.
           LV_DELTA_COL = LV_MAX_COL - IV_SKIPPED_COLS.
           assign component LV_DELTA_COL of structure <LS_LINE> to <LV_VALUE>.
           if SY-SUBRC <> 0 or <LV_VALUE> is not assigned.
             LV_ERRORMESSAGE = 'Internal table has less columns than excel'(003).
-            raise exception type ZCX_EXCEL
-              exporting
-                ERROR = LV_ERRORMESSAGE.
+            zcx_excel=>raise_text( lv_errormessage ).
           else.
 *--------------------------------------------------------------------*
 *now we are ready for handle the table data
@@ -4221,9 +4205,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
               append initial line to ET_TABLE assigning <LS_LINE>.
               if SY-SUBRC <> 0 or <LS_LINE> is not assigned.
                 LV_ERRORMESSAGE = 'Error at inserting new Line to internal Table'(002).
-                raise exception type ZCX_EXCEL
-                  exporting
-                    ERROR = LV_ERRORMESSAGE.
+                zcx_excel=>raise_text( lv_errormessage ).
               endif.
               while LV_ACTUAL_COL <= LV_MAX_COL.
 
@@ -4231,9 +4213,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
                 assign component LV_DELTA_COL of structure <LS_LINE> to <LV_VALUE>.
                 if SY-SUBRC <> 0.
                   LV_ERRORMESSAGE = |{ 'Error at assigning field (Col:'(004) } { LV_ACTUAL_COL } { ' Row:'(005) } { LV_ACTUAL_ROW }|.
-                  raise exception type ZCX_EXCEL
-                    exporting
-                      ERROR = LV_ERRORMESSAGE.
+                  zcx_excel=>raise_text( lv_errormessage ).
                 endif.
 
                 ME->GET_CELL(
@@ -4247,9 +4227,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
                 if LV_RC <> 0
                   and LV_RC <> 4.                                                   "No found error means, zero/no value in cell
                   LV_ERRORMESSAGE = |{ 'Error at reading field value (Col:'(007) } { LV_ACTUAL_COL } { ' Row:'(005) } { LV_ACTUAL_ROW }|.
-                  raise exception type ZCX_EXCEL
-                    exporting
-                      ERROR = LV_ERRORMESSAGE.
+                  zcx_excel=>raise_text( lv_errormessage ).
                 endif.
 
                 <LV_VALUE> = LV_VALUE.
@@ -4265,24 +4243,16 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
 
       catch CX_SY_ASSIGN_CAST_ILLEGAL_CAST.
         LV_ERRORMESSAGE = |{ 'Error at assigning field (Col:'(004) } { LV_ACTUAL_COL } { ' Row:'(005) } { LV_ACTUAL_ROW }|.
-        raise exception type ZCX_EXCEL
-          exporting
-            ERROR = LV_ERRORMESSAGE.
+        zcx_excel=>raise_text( lv_errormessage ).
       catch CX_SY_ASSIGN_CAST_UNKNOWN_TYPE.
         LV_ERRORMESSAGE = |{ 'Error at assigning field (Col:'(004) } { LV_ACTUAL_COL } { ' Row:'(005) } { LV_ACTUAL_ROW }|.
-        raise exception type ZCX_EXCEL
-          exporting
-            ERROR = LV_ERRORMESSAGE.
+        zcx_excel=>raise_text( lv_errormessage ).
       catch CX_SY_ASSIGN_OUT_OF_RANGE.
         LV_ERRORMESSAGE = 'Internal table has less columns than excel'(003).
-        raise exception type ZCX_EXCEL
-          exporting
-            ERROR = LV_ERRORMESSAGE.
+        zcx_excel=>raise_text( lv_errormessage ).
       catch CX_SY_CONVERSION_ERROR.
         LV_ERRORMESSAGE = |{ 'Error at converting field value (Col:'(006) } { LV_ACTUAL_COL } { ' Row:'(005) } { LV_ACTUAL_ROW }|.
-        raise exception type ZCX_EXCEL
-          exporting
-            ERROR = LV_ERRORMESSAGE.
+        zcx_excel=>raise_text( lv_errormessage ).
 
     endtry.
   endmethod.
@@ -4512,9 +4482,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
                    <FS_VALUE>         type SIMPLE.
 
     if IP_VALUE  is not supplied and IP_FORMULA is not supplied.
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = 'Please provide the value or formula'.
+      zcx_excel=>raise_text( 'Please provide the value or formula' ).
     endif.
 
 * Begin of change issue #152 - don't touch exisiting style if only value is passed
@@ -4617,9 +4585,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
 * End of change issue #152 - don't touch exisiting style if only value is passed
 
           when others.
-            raise exception type ZCX_EXCEL
-              exporting
-                ERROR = 'Invalid data type of input value'.
+            zcx_excel=>raise_text( 'Invalid data type of input value' ).
         endcase.
       endif.
 
@@ -4781,17 +4747,13 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
       try.
           WIDTH = IP_WIDTH_FIX.
           if WIDTH <= 0.
-            raise exception type ZCX_EXCEL
-              exporting
-                ERROR = 'Please supply a positive number as column-width'.
+            zcx_excel=>raise_text( 'Please supply a positive number as column-width' ).
           endif.
           LO_COLUMN->SET_WIDTH( WIDTH ).
           exit.
         catch CX_SY_CONVERSION_NO_NUMBER.
 * Strange stuff passed --> raise error
-          raise exception type ZCX_EXCEL
-            exporting
-              ERROR = 'Unable to interpret supplied input as number'.
+          zcx_excel=>raise_text( 'Unable to interpret supplied input as number' ).
       endtry.
     endif.
 
@@ -4805,9 +4767,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
   method SET_DEFAULT_EXCEL_DATE_FORMAT.
 
     if IP_DEFAULT_EXCEL_DATE_FORMAT is initial.
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = 'Default date format cannot be blank'.
+      zcx_excel=>raise_text( 'Default date format cannot be blank' ).
     endif.
 
     DEFAULT_EXCEL_DATE_FORMAT = IP_DEFAULT_EXCEL_DATE_FORMAT.
@@ -4830,9 +4790,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
     endif.
     if LS_MERGE-ROW_FROM > LS_MERGE-ROW_TO.
       LV_ERRORMESSAGE = 'Merge: First row larger then last row'(405).
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = LV_ERRORMESSAGE.
+      zcx_excel=>raise_text( lv_errormessage ).
     endif.
 
     LS_MERGE-COL_FROM = ZCL_EXCEL_COMMON=>CONVERT_COLUMN2INT( IP_COLUMN_START ).
@@ -4843,9 +4801,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
     endif.
     if LS_MERGE-COL_FROM > LS_MERGE-COL_TO.
       LV_ERRORMESSAGE = 'Merge: First column larger then last column'(406).
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = LV_ERRORMESSAGE.
+      zcx_excel=>raise_text( lv_errormessage ).
     endif.
 
 *--------------------------------------------------------------------*
@@ -4856,9 +4812,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
                                                                    or COL_FROM > LS_MERGE-COL_TO
                                                                    or COL_TO   < LS_MERGE-COL_FROM ).
       LV_ERRORMESSAGE = 'Overlapping merges'(404).
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = LV_ERRORMESSAGE.
+      zcx_excel=>raise_text( lv_errormessage ).
 
     endloop.
 
@@ -4885,17 +4839,13 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
     try.
         HEIGHT = IP_HEIGHT_FIX.
         if HEIGHT <= 0.
-          raise exception type ZCX_EXCEL
-            exporting
-              ERROR = 'Please supply a positive number as row-height'.
+          zcx_excel=>raise_text( 'Please supply a positive number as row-height' ).
         endif.
         LO_ROW->SET_ROW_HEIGHT( HEIGHT ).
         exit.
       catch CX_SY_CONVERSION_NO_NUMBER.
 * Strange stuff passed --> raise error
-        raise exception type ZCX_EXCEL
-          exporting
-            ERROR = 'Unable to interpret supplied input as number'.
+        zcx_excel=>raise_text( 'Unable to interpret supplied input as number' ).
     endtry.
 
   endmethod.
@@ -4910,14 +4860,10 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
                                                                              ROW_TO   = IV_ROW_TO.
     if SY-SUBRC <> 0.
       if IV_ROW_FROM <= 0.
-        raise exception type ZCX_EXCEL
-          exporting
-            ERROR = 'First row of outline must be a positive number'.
+        zcx_excel=>raise_text( 'First row of outline must be a positive number' ).
       endif.
       if IV_ROW_TO < IV_ROW_FROM.
-        raise exception type ZCX_EXCEL
-          exporting
-            ERROR = 'Last row of outline may not be less than first line of outline'.
+        zcx_excel=>raise_text( 'Last row of outline may not be less than first line of outline' ).
       endif.
       LS_ROW_OUTLINE-ROW_FROM = IV_ROW_FROM.
       LS_ROW_OUTLINE-ROW_TO   = IV_ROW_TO.
@@ -4931,9 +4877,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
         <LS_ROW_OUTLINE>-COLLAPSED = IV_COLLAPSED.
 
       when others.
-        raise exception type ZCX_EXCEL
-          exporting
-            ERROR = 'Unknown collapse state'.
+        zcx_excel=>raise_text( 'Unknown collapse state' ).
 
     endcase.
   endmethod.
@@ -5062,17 +5006,13 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
 *--------------------------------------------------------------------*
     if IP_TITLE ca '/\[]*?:'.
       LV_ERRORMESSAGE = 'Found illegal character in sheetname. List of forbidden characters: /\[]*?:'(402).
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = LV_ERRORMESSAGE.
+      zcx_excel=>raise_text( lv_errormessage ).
     endif.
 
     if IP_TITLE is not initial and IP_TITLE(1) = `'`.
       LV_ERRORMESSAGE = 'Sheetname may not start with &'(403).   " & used instead of ' to allow fallbacklanguage
       replace '&' in LV_ERRORMESSAGE with `'`.
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = LV_ERRORMESSAGE.
+      zcx_excel=>raise_text( lv_errormessage ).
     endif.
 
 
@@ -5087,9 +5027,7 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
       if IP_TITLE = LO_WORKSHEET->GET_TITLE( ).  " Not unique --> raise exception
         ERRORMESSAGE = 'Duplicate sheetname &'.
         replace '&' in ERRORMESSAGE with IP_TITLE.
-        raise exception type ZCX_EXCEL
-          exporting
-            ERROR = ERRORMESSAGE.
+        zcx_excel=>raise_text( errormessage ).
       endif.
 
     endwhile.
@@ -5237,16 +5175,12 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
 *--------------------------------------------------------------------*
     if LV_COL_FROM_INT < 1.
       LV_ERRORMESSAGE = 'Invalid range supplied for print-title repeatable columns'(401).
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = LV_ERRORMESSAGE.
+      zcx_excel=>raise_text( lv_errormessage ).
     endif.
 
     if  LV_COL_FROM_INT > LV_COL_TO_INT.
       LV_ERRORMESSAGE = 'Invalid range supplied for print-title repeatable columns'(401).
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = LV_ERRORMESSAGE.
+      zcx_excel=>raise_text( lv_errormessage ).
     endif.
 
 *--------------------------------------------------------------------*
@@ -5278,16 +5212,12 @@ CLASS ZCL_EXCEL_WORKSHEET IMPLEMENTATION.
 *--------------------------------------------------------------------*
     if IV_ROWS_FROM < 1.
       LV_ERRORMESSAGE = 'Invalid range supplied for print-title repeatable rowumns'(401).
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = LV_ERRORMESSAGE.
+      zcx_excel=>raise_text( lv_errormessage ).
     endif.
 
     if  IV_ROWS_FROM > IV_ROWS_TO.
       LV_ERRORMESSAGE = 'Invalid range supplied for print-title repeatable rowumns'(401).
-      raise exception type ZCX_EXCEL
-        exporting
-          ERROR = LV_ERRORMESSAGE.
+      zcx_excel=>raise_text( lv_errormessage ).
     endif.
 
 *--------------------------------------------------------------------*

--- a/src/zcx_excel.clas.abap
+++ b/src/zcx_excel.clas.abap
@@ -5,9 +5,13 @@ class ZCX_EXCEL definition
 
 *"* public components of class ZCX_EXCEL
 *"* do not include other source files here!!!
+*"* protected components of class ZCX_EXCEL
+*"* do not include other source files here!!!
+*"* protected components of class ZCX_EXCEL
+*"* do not include other source files here!!!
 public section.
 
-  constants ZCX_EXCEL type SOTR_CONC value '028C0ED2B5601ED78EB6F3368B1E4F9B'. "#EC NOTEXT
+  constants ZCX_EXCEL type SOTR_CONC value '028C0ED2B5601ED78EB6F3368B1E4F9B' ##NO_TEXT.
   data ERROR type STRING .
   data SYST_AT_RAISE type SYST .
 
@@ -17,15 +21,19 @@ public section.
       !PREVIOUS like PREVIOUS optional
       !ERROR type STRING optional
       !SYST_AT_RAISE type SYST optional .
+  class-methods RAISE_TEXT
+    importing
+      !IV_TEXT type CLIKE
+    raising
+      ZCX_EXCEL .
+  class-methods RAISE_SYMSG
+    raising
+      ZCX_EXCEL .
 
   methods IF_MESSAGE~GET_LONGTEXT
     redefinition .
   methods IF_MESSAGE~GET_TEXT
     redefinition .
-*"* protected components of class ZCX_EXCEL
-*"* do not include other source files here!!!
-*"* protected components of class ZCX_EXCEL
-*"* do not include other source files here!!!
 protected section.
 *"* private components of class ZCX_EXCEL
 *"* do not include other source files here!!!
@@ -37,7 +45,7 @@ ENDCLASS.
 CLASS ZCX_EXCEL IMPLEMENTATION.
 
 
-method CONSTRUCTOR.
+  method CONSTRUCTOR.
 CALL METHOD SUPER->CONSTRUCTOR
 EXPORTING
 TEXTID = TEXTID
@@ -48,7 +56,7 @@ PREVIOUS = PREVIOUS
  ENDIF.
 me->ERROR = ERROR .
 me->SYST_AT_RAISE = SYST_AT_RAISE .
-endmethod.
+  endmethod.
 
 
 method IF_MESSAGE~GET_LONGTEXT.
@@ -93,5 +101,19 @@ method IF_MESSAGE~GET_TEXT.
       RECEIVING
         result = result.
   ENDIF.
+  endmethod.
+
+
+  method RAISE_SYMSG.
+    raise exception type zcx_excel
+      exporting
+        syst_at_raise = syst.
+  endmethod.
+
+
+  method RAISE_TEXT.
+    raise exception type zcx_excel
+      exporting
+        error = iv_text.
   endmethod.
 ENDCLASS.


### PR DESCRIPTION
### Text exception
Before
```
RAISE EXCEPTION TYPE zcx_excel	      
  EXPORTING	
    error = lv_errormessage.
```
After
```
zcx_excel=>raise_text( lv_errormessage ).
```

### Sy-msg exception
Before
```
MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
RAISE EXCEPTION TYPE zcx_excel
  EXPORTING
    syst_at_raise = syst.
```

After
```
MESSAGE e800(zabap2xlsx) INTO lv_errormessage.
zcx_excel=>raise_symsg( ).
```