### PR TITLE
remove illegal files from the XML

### DIFF
--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -7819,6 +7819,17 @@ METHOD render_xml_document.
 
   lo_streamfactory = me->ixml->create_stream_factory( ).
   lo_ostream = lo_streamfactory->create_ostream_xstring( string = ep_content ).
+  
+  " remove illegal characters in the XML according to the note 1750204
+  " the following method is only available if the corresponding kernel is used
+  TRY.
+      CALL METHOD lo_ostream->('SKIP_NON_XML_CHARACTERS')
+        EXPORTING
+          is_skipping = abap_true.
+    CATCH cx_sy_dyn_call_illegal_method.
+
+  ENDTRY.
+  
   lo_renderer = me->ixml->create_renderer( ostream  = lo_ostream document = io_document ).
   lo_renderer->render( ).
 ENDMETHOD.


### PR DESCRIPTION
according to the SAP note 1750204 we can use the method IF_IXML_OSTREAM->SKIP_NON_XML_CHARACTERS to strip out illegal characters for XML rendering.
Since this method needs a kernel version with builtin support, I've made the call dynamically in a try/catch block to support systems with a lower kernel too.

This patch fixes the issues from #298 (at least for us)