### PR TITLE
Update zcl_excel_writer_2007.clas.abap

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -13,7 +13,7 @@
     "globalMacros": []
   },
   "rules": {
-    "prefix_is_current_class": false,
+    "prefix_is_current_class": true,
     "unused_variables": false,
     "abapdoc": false,
     "allowed_object_naming": true,

--- a/abaplint.json
+++ b/abaplint.json
@@ -13,7 +13,7 @@
     "globalMacros": []
   },
   "rules": {
-    "prefix_is_current_class": true,
+    "prefix_is_current_class": false,
     "unused_variables": false,
     "abapdoc": false,
     "allowed_object_naming": true,

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -3568,7 +3568,7 @@ METHOD create_xl_sharedstrings.
     MOVE lv_sytabix                    TO ls_shared_string-string_no.
     MOVE <fs_sheet_content>-cell_value TO ls_shared_string-string_value.
     MOVE <fs_sheet_content>-data_type TO ls_shared_string-string_type.
-    APPEND ls_shared_string TO shared_strings.
+    INSERT ls_shared_string INTO TABLE shared_strings.
     add 1 to lv_count.
   ENDLOOP.
 


### PR DESCRIPTION
internal table shared_strings  is type sorted table , and there was an append statement used to append and entry to this internal table . 
as this is sorted table we should not be using append statement as it leads to run-time dump so modifying code by replacing append statement with insert statement. 
