### PR TITLE
Reading corrupted xlsx file

### DIFF
--- a/src/zcl_excel_reader_2007.clas.abap
+++ b/src/zcl_excel_reader_2007.clas.abap
@@ -2455,8 +2455,10 @@ METHOD load_worksheet.
 
       CASE ls_cell-t.
         WHEN 's'. " String values are stored as index in shared string table
-          lv_index = lo_ixml_value_elem->get_value( ) + 1.
-          READ TABLE shared_strings INTO lv_cell_value INDEX lv_index.
+          IF lo_ixml_value_elem IS BOUND.
+            lv_index = lo_ixml_value_elem->get_value( ) + 1.
+            READ TABLE shared_strings INTO lv_cell_value INDEX lv_index.
+          ENDIF.
         WHEN 'inlineStr'. " inlineStr values are kept in special node
           lo_ixml_value_elem = lo_ixml_cell_elem->find_from_name( name = 'is' ).
           IF lo_ixml_value_elem IS BOUND.


### PR DESCRIPTION
A cell contained text in the original template. It was lated deleted. But apparently a link to SharedStrings from the cell was not removed. An exception occurred after downloading and opening the file via ZCL_EXCELL_READER_2007 class. All operations until ZCL_EXCEL_READER_2007 were done using other tools.