### PR TITLE
Update zcl_excel_converter.clas.abap

### DIFF
--- a/src/zcl_excel_converter.clas.abap
+++ b/src/zcl_excel_converter.clas.abap
@@ -1415,7 +1415,6 @@ method LOOP_SUBTOTAL.
   LOOP AT wt_fieldcatalog ASSIGNING <fs_sfcat>.
     l_row_int = i_row_int.
     l_col_int = i_col_int + <fs_sfcat>-position - 1.
-    
 * Freeze panes
     IF <fs_sfcat>-fix_column = abap_true.
       ADD 1 TO r_freeze_col.

--- a/src/zcl_excel_converter.clas.abap
+++ b/src/zcl_excel_converter.clas.abap
@@ -1159,10 +1159,6 @@ method LOOP_NORMAL.
     l_row_int = i_row_int.
     l_col_int = i_col_int + <fs_sfcat>-position - 1.
 
-* ignore ALV-color-column (deep data type)
-*   'h' = table, e.g. color column in ALV
-    CHECK <fs_sfcat>-inttype NE 'h'.
-    
 *   Freeze panes
     IF <fs_sfcat>-fix_column = abap_true.
       ADD 1 TO r_freeze_col.
@@ -1419,10 +1415,6 @@ method LOOP_SUBTOTAL.
   LOOP AT wt_fieldcatalog ASSIGNING <fs_sfcat>.
     l_row_int = i_row_int.
     l_col_int = i_col_int + <fs_sfcat>-position - 1.
-    
-* ignore ALV-color-column (deep data type)
-*   'h' = table, e.g. color column in ALV
-    CHECK <fs_sfcat>-inttype NE 'h'.    
     
 * Freeze panes
     IF <fs_sfcat>-fix_column = abap_true.

--- a/src/zcl_excel_converter.clas.abap
+++ b/src/zcl_excel_converter.clas.abap
@@ -1159,6 +1159,10 @@ method LOOP_NORMAL.
     l_row_int = i_row_int.
     l_col_int = i_col_int + <fs_sfcat>-position - 1.
 
+* ignore ALV-color-column (deep data type)
+*   'h' = table, e.g. color column in ALV
+    CHECK <fs_sfcat>-inttype NE 'h'.
+    
 *   Freeze panes
     IF <fs_sfcat>-fix_column = abap_true.
       ADD 1 TO r_freeze_col.
@@ -1415,6 +1419,11 @@ method LOOP_SUBTOTAL.
   LOOP AT wt_fieldcatalog ASSIGNING <fs_sfcat>.
     l_row_int = i_row_int.
     l_col_int = i_col_int + <fs_sfcat>-position - 1.
+    
+* ignore ALV-color-column (deep data type)
+*   'h' = table, e.g. color column in ALV
+    CHECK <fs_sfcat>-inttype NE 'h'.    
+    
 * Freeze panes
     IF <fs_sfcat>-fix_column = abap_true.
       ADD 1 TO r_freeze_col.

--- a/src/zdemo_excel.prog.abap
+++ b/src/zdemo_excel.prog.abap
@@ -66,7 +66,7 @@ START-OF-SELECTION.
   " SUBMIT zdemo_excel29 WITH rb_down = abap_true WITH rb_show = abap_false WITH  p_path  = p_path AND RETURN. "#EC CI_SUBMIT abap2xlsx Demo: Macro enabled workbook
   SUBMIT zdemo_excel30 WITH rb_down = abap_true WITH rb_show = abap_false WITH  p_path    = p_path AND RETURN. "#EC CI_SUBMIT abap2xlsx Demo: ABAP Cell data types + leading blanks string
   SUBMIT zdemo_excel31 WITH rb_down = abap_true WITH rb_show = abap_false WITH  p_path    = p_path AND RETURN. "#EC CI_SUBMIT abap2xlsx Demo: Autosize Column with different Font sizes
-  " zdemo_excel32 is not added because it uses ALV and cannot be processed (Native)
+  SUBMIT zdemo_excel32 WITH rb_down = abap_true WITH rb_show = abap_false WITH  p_path    = p_path AND RETURN. "#EC CI_SUBMIT abap2xlsx Demo: Demo for export options from ALV GRID
   SUBMIT zdemo_excel33 WITH rb_down = abap_true WITH rb_show = abap_false WITH  p_path    = p_path AND RETURN. "#EC CI_SUBMIT abap2xlsx Demo: Table autofilter
   SUBMIT zdemo_excel34 WITH rb_down = abap_true WITH rb_show = abap_false WITH  p_path    = p_path AND RETURN. "#EC CI_SUBMIT abap2xlsx Demo: Static Styles Chess
   SUBMIT zdemo_excel35 WITH rb_down = abap_true WITH rb_show = abap_false WITH  p_path    = p_path AND RETURN. "#EC CI_SUBMIT abap2xlsx Demo: Static Styles


### PR DESCRIPTION
Converting an ALV table that includes a color column failed because deep tables are not supported. The check that was addes prevents an error.