### PR TITLE
Enable Show DropDown

### DIFF
--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -3757,7 +3757,7 @@ METHOD create_xl_sheet.
         lc_xml_attr_allowblank         TYPE string VALUE 'allowBlank',
         lc_xml_attr_showinputmessage   TYPE string VALUE 'showInputMessage',
         lc_xml_attr_showerrormessage   TYPE string VALUE 'showErrorMessage',
-        lc_xml_attr_showdropdown       TYPE string VALUE 'showDropDown',
+        lc_xml_attr_showdropdown       TYPE string VALUE 'ShowDropDown', " 'showDropDown' does not work
         lc_xml_attr_errortitle         TYPE string VALUE 'errorTitle',
         lc_xml_attr_error              TYPE string VALUE 'error',
         lc_xml_attr_prompttitle        TYPE string VALUE 'promptTitle',

--- a/src/zdemo_excel45.prog.abap
+++ b/src/zdemo_excel45.prog.abap
@@ -1,0 +1,66 @@
+*&---------------------------------------------------------------------*
+*& Report  ZDEMO_EXCEL45
+*&
+*&---------------------------------------------------------------------*
+*&
+*&
+*&---------------------------------------------------------------------*
+REPORT zdemo_excel45.
+
+CONSTANTS:
+  gc_ws_title_validation TYPE zexcel_sheet_title VALUE 'Validation'.
+
+DATA:
+  lo_excel             TYPE REF TO zcl_excel,
+  lo_worksheet         TYPE REF TO zcl_excel_worksheet,
+  lo_range             TYPE REF TO zcl_excel_range,
+  lv_validation_string TYPE string,
+  lo_data_validation   TYPE REF TO zcl_excel_data_validation,
+  lv_row               TYPE zexcel_cell_row.
+
+
+CONSTANTS:
+  gc_save_file_name TYPE string VALUE '45_ShowDropdown.xlsx'.
+
+INCLUDE zdemo_excel_outputopt_incl.
+
+
+START-OF-SELECTION.
+
+*** Sheet Admin
+
+* Creates active sheet
+  CREATE OBJECT lo_excel.
+
+* Get active sheet
+  lo_worksheet = lo_excel->get_active_worksheet( ).
+
+* Set sheet name "Validation"
+  lo_worksheet->set_title( gc_ws_title_validation ).
+
+
+* short validations can be entered as string (<254Char)
+  lv_validation_string = '"New York, Rio, Tokyo"'.
+
+* create validation object
+  lo_data_validation = lo_worksheet->add_new_data_validation( ).
+
+* create new validation from validation string
+  lo_data_validation->type           = zcl_excel_data_validation=>c_type_list.
+  lo_data_validation->formula1       = lv_validation_string.
+  lo_data_validation->cell_row       = 2.
+  lo_data_validation->cell_row_to    = 4.
+  lo_data_validation->cell_column    = 'A'.
+  lo_data_validation->cell_column_to = 'A'.
+  lo_data_validation->allowblank     = 'X'.
+  lo_data_validation->showdropdown   = 'X'.
+
+* add some fields with validation
+  lv_row = 2.
+  WHILE lv_row <= 4.
+    lo_worksheet->set_cell( ip_row = lv_row ip_column = 'A' ip_value = 'Select' ).
+    lv_row = lv_row + 1.
+  ENDWHILE.
+
+*** Create output
+  lcl_output=>output( lo_excel ).

--- a/src/zdemo_excel45.prog.xml
+++ b/src/zdemo_excel45.prog.xml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <PROGDIR>
+    <NAME>ZDEMO_EXCEL45</NAME>
+    <SUBC>1</SUBC>
+    <RLOAD>E</RLOAD>
+    <FIXPT>X</FIXPT>
+    <UCCHECK>X</UCCHECK>
+   </PROGDIR>
+   <TPOOL>
+    <item>
+     <ID>R</ID>
+     <ENTRY>abap2xlsx Demo: Show Dropdown</ENTRY>
+     <LENGTH>29</LENGTH>
+    </item>
+   </TPOOL>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
### Enable display of DropDownList when using inline value list

**Test-Report:**
> zdemo_excel45

**Description:**
When using a value list defined from a string (not by a range), the feature to display the values from a drop down list is not working yet. Reverse engineering the XLSX file generated by Excel (kudos to Oliver Loose) shows that the attribute 'ShowDropDown' needs to start with an capital S, otherwise the drop down list is not displayed. Behavior can be easily reproduced with the test report zdemo_excel45 included in this commit.

Please merge this change into the main release to enable the drop down feature in string value lists.

Best regards,
Harald Bucher