### PR TITLE
Enable ValidationStyle in Value Lists

### DIFF
--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -3760,6 +3760,7 @@ METHOD create_xl_sheet.
         lc_xml_attr_showdropdown       TYPE string VALUE 'showDropDown',
         lc_xml_attr_errortitle         TYPE string VALUE 'errorTitle',
         lc_xml_attr_error              TYPE string VALUE 'error',
+        lc_xml_attr_errorstyle         TYPE string VALUE 'errorStyle',
         lc_xml_attr_prompttitle        TYPE string VALUE 'promptTitle',
         lc_xml_attr_prompt             TYPE string VALUE 'prompt',
         lc_xml_attr_count              TYPE string VALUE 'count',
@@ -4871,6 +4872,11 @@ METHOD create_xl_sheet.
       IF NOT lo_data_validation->error IS INITIAL.
         lv_value = lo_data_validation->error.
         lo_element_2->set_attribute_ns( name  = lc_xml_attr_error
+                                        value = lv_value ).
+      ENDIF.
+      IF NOT lo_data_validation->errorstyle IS INITIAL.
+        lv_value = lo_data_validation->errorstyle.
+        lo_element_2->set_attribute_ns( name  = lc_xml_attr_errorstyle
                                         value = lv_value ).
       ENDIF.
       IF NOT lo_data_validation->prompttitle IS INITIAL.

--- a/src/zdemo_excel46.prog.abap
+++ b/src/zdemo_excel46.prog.abap
@@ -1,0 +1,71 @@
+*&---------------------------------------------------------------------*
+*& Report  ZDEMO_EXCEL46
+*&
+*&---------------------------------------------------------------------*
+*&
+*&
+*&---------------------------------------------------------------------*
+REPORT zdemo_excel46.
+
+CONSTANTS:
+  gc_ws_title_validation TYPE zexcel_sheet_title VALUE 'Validation'.
+
+DATA:
+  lo_excel             TYPE REF TO zcl_excel,
+  lo_worksheet         TYPE REF TO zcl_excel_worksheet,
+  lo_range             TYPE REF TO zcl_excel_range,
+  lv_validation_string TYPE string,
+  lo_data_validation   TYPE REF TO zcl_excel_data_validation,
+  lv_row               TYPE zexcel_cell_row.
+
+
+CONSTANTS:
+  gc_save_file_name TYPE string VALUE '46_ValidationWarning.xlsx'.
+
+INCLUDE zdemo_excel_outputopt_incl.
+
+
+START-OF-SELECTION.
+
+*** Sheet Validation
+
+* Creates active sheet
+  CREATE OBJECT lo_excel.
+
+* Get active sheet
+  lo_worksheet = lo_excel->get_active_worksheet( ).
+
+* Set sheet name "Validation"
+  lo_worksheet->set_title( gc_ws_title_validation ).
+
+
+* short validations can be entered as string (<254Char)
+  lv_validation_string = '"New York, Rio, Tokyo"'.
+
+* create validation object
+  lo_data_validation = lo_worksheet->add_new_data_validation( ).
+
+* create new validation from validation string
+  lo_data_validation->type           = zcl_excel_data_validation=>c_type_list.
+  lo_data_validation->formula1       = lv_validation_string.
+  lo_data_validation->cell_row       = 2.
+  lo_data_validation->cell_row_to    = 4.
+  lo_data_validation->cell_column    = 'A'.
+  lo_data_validation->cell_column_to = 'A'.
+  lo_data_validation->allowblank     = 'X'.
+  lo_data_validation->showdropdown   = 'X'.
+  lo_data_validation->prompttitle    = 'Value list available'.
+  lo_data_validation->prompt         = 'Please select a value from the value list'.
+  lo_data_validation->errorstyle     = zcl_excel_data_validation=>c_style_warning.
+  lo_data_validation->errortitle     = 'Warning'.
+  lo_data_validation->error          = 'This value does not exist in current value list.'.
+
+* add some fields with validation
+  lv_row = 2.
+  WHILE lv_row <= 4.
+    lo_worksheet->set_cell( ip_row = lv_row ip_column = 'A' ip_value = 'Select' ).
+    lv_row = lv_row + 1.
+  ENDWHILE.
+
+*** Create output
+  lcl_output=>output( lo_excel ).

--- a/src/zdemo_excel46.prog.xml
+++ b/src/zdemo_excel46.prog.xml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_PROG" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <PROGDIR>
+    <NAME>ZDEMO_EXCEL46</NAME>
+    <SUBC>1</SUBC>
+    <RLOAD>E</RLOAD>
+    <FIXPT>X</FIXPT>
+    <UCCHECK>X</UCCHECK>
+   </PROGDIR>
+   <TPOOL>
+    <item>
+     <ID>R</ID>
+     <ENTRY>abap2xlsx Demo: Validation Style Warning</ENTRY>
+     <LENGTH>40</LENGTH>
+    </item>
+   </TPOOL>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Enable errorStyle (Error/Warning/...) for validation with value list.
When a value list is defined for a cell, default behavior is an error if the entered value does not match the value list. With this pull request, the behavior can be changed to i.e. a warning, which lets the user decide if a entered value which is not in the value list can be accepted anyway. 
To demonstrate this feature, report zdemo_excel46 was added.