### PR TITLE
Feature: Enable custom converters

### DIFF
--- a/src/zcl_excel_converter.clas.abap
+++ b/src/zcl_excel_converter.clas.abap
@@ -937,7 +937,8 @@ endmethod.
       ls_impkey                 TYPE seor_implementing_key,
       ls_classkey               TYPE seoclskey,
       lr_implementation         TYPE REF TO zif_excel_converter,
-      ls_object                 TYPE ts_alv_types.
+      ls_object                 TYPE ts_alv_types,
+      lr_classdescr             TYPE REF TO cl_abap_classdescr.
 
     ls_classkey-clsname = 'ZIF_EXCEL_CONVERTER'.
 
@@ -952,7 +953,8 @@ endmethod.
     CHECK sy-subrc = 0.
 
     LOOP AT lt_direct_implementations INTO ls_impkey.
-      IF cl_abap_classdescr=>describe_by_name( ls_impkey-clsname )->is_instantiatable( ) = abap_true.
+      lr_classdescr ?= cl_abap_classdescr=>describe_by_name( ls_impkey-clsname ).
+      IF lr_classdescr->is_instantiatable( ) = abap_true.
         APPEND ls_impkey TO lt_all_implementations.
       ENDIF.
 
@@ -1157,7 +1159,9 @@ method GET_STYLE.
 
   METHOD get_subclasses.
     DATA:
-      lt_subclasses TYPE seor_inheritance_keys.
+      lt_subclasses TYPE seor_inheritance_keys,
+      ls_subclass   TYPE seor_inheritance_key,
+      lr_classdescr TYPE REF TO cl_abap_classdescr.
 
     CALL FUNCTION 'SEO_CLASS_GET_ALL_SUBS'
       EXPORTING
@@ -1170,8 +1174,9 @@ method GET_STYLE.
 
     CHECK sy-subrc = 0.
 
-    LOOP AT lt_subclasses INTO DATA(ls_subclass).
-      IF cl_abap_classdescr=>describe_by_name( ls_subclass-clsname )->is_instantiatable( ).
+    LOOP AT lt_subclasses INTO ls_subclass.
+      lr_classdescr ?= cl_abap_classdescr=>describe_by_name( ls_subclass-clsname ).
+      IF lr_classdescr->is_instantiatable( ) = abap_true.
         APPEND ls_subclass TO ct_classes.
       ENDIF.
     ENDLOOP.

--- a/src/zcl_excel_converter.clas.abap
+++ b/src/zcl_excel_converter.clas.abap
@@ -84,6 +84,11 @@ protected section.
 *"* private components of class ZCL_EXCEL_CONVERTER
 *"* do not include other source files here!!!
 private section.
+  CLASS-METHODS get_subclasses
+    IMPORTING
+      is_clskey  TYPE seoclskey
+    CHANGING
+      ct_classes TYPE seor_implementing_keys.
 
   data WO_EXCEL type ref to ZCL_EXCEL .
   data WO_WORKSHEET type ref to ZCL_EXCEL_WORKSHEET .
@@ -109,6 +114,7 @@ private section.
   class-data WS_INDX type INDX .
 
   class-methods INIT_OPTION .
+  class-methods GET_ALV_CONVERTERS.
   methods BIND_TABLE
     importing
       !I_STYLE_TABLE type ZEXCEL_TABLE_STYLE
@@ -404,24 +410,7 @@ method CLASS_CONSTRUCTOR.
     l_uname = sy-uname.
   ENDIF.
 
-* Object CL_GUI_ALV_GRID
-  ls_objects-seoclass  = 'CL_GUI_ALV_GRID'.
-  ls_objects-clsname   = 'ZCL_EXCEL_CONVERTER_ALV_GRID'.
-  INSERT ls_objects INTO TABLE wt_objects.
-
-* Object CL_SALV_TABLE
-  ls_objects-seoclass  = 'CL_SALV_TABLE'.
-  ls_objects-clsname   = 'ZCL_EXCEL_CONVERTER_SALV_TABLE'.
-  INSERT ls_objects INTO TABLE wt_objects.
-
-* Object CL_SALV_RESULT
-  ls_objects-seoclass  = 'CL_SALV_EX_RESULT_DATA_TABLE '.
-  ls_objects-clsname   = 'ZCL_EXCEL_CONVERTER_RESULT_EX'.
-  INSERT ls_objects INTO TABLE wt_objects.
-* Object CL_SALV_WD_RESULT
-  ls_objects-seoclass  = 'CL_SALV_WD_RESULT_DATA_TABLE '.
-  ls_objects-clsname   = 'ZCL_EXCEL_CONVERTER_RESULT_WD'.
-  INSERT ls_objects INTO TABLE wt_objects.
+  get_alv_converters( ).
 
   CONCATENATE 'EXCEL_' sy-uname INTO ws_indx-srtfd.
 
@@ -941,6 +930,52 @@ method EXECUTE_CONVERTER.
 endmethod.
 
 
+  METHOD get_alv_converters.
+    DATA:
+      lt_direct_implementations TYPE seor_implementing_keys,
+      lt_all_implementations    TYPE seor_implementing_keys,
+      ls_impkey                 TYPE seor_implementing_key,
+      ls_classkey               TYPE seoclskey,
+      lr_implementation         TYPE REF TO zif_excel_converter,
+      ls_object                 TYPE ts_alv_types.
+
+    ls_classkey-clsname = 'ZIF_EXCEL_CONVERTER'.
+
+    CALL FUNCTION 'SEO_INTERFACE_IMPLEM_GET_ALL'
+      EXPORTING
+        intkey  = ls_classkey
+      IMPORTING
+        impkeys = lt_direct_implementations
+      EXCEPTIONS
+        OTHERS  = 2.
+
+    CHECK sy-subrc = 0.
+
+    LOOP AT lt_direct_implementations INTO ls_impkey.
+      IF cl_abap_classdescr=>describe_by_name( ls_impkey-clsname )->is_instantiatable( ) = abap_true.
+        APPEND ls_impkey TO lt_all_implementations.
+      ENDIF.
+
+      ls_classkey-clsname = ls_impkey-clsname.
+      get_subclasses( EXPORTING is_clskey = ls_classkey CHANGING ct_classes = lt_all_implementations ).
+    ENDLOOP.
+
+    SORT lt_all_implementations BY clsname.
+    DELETE ADJACENT DUPLICATES FROM lt_all_implementations COMPARING clsname.
+
+    LOOP AT lt_all_implementations into ls_impkey.
+      CLEAR ls_object.
+      CREATE OBJECT lr_implementation TYPE (ls_impkey-clsname).
+      ls_object-seoclass = lr_implementation->get_supported_class( ).
+
+      IF ls_object-seoclass IS NOT INITIAL.
+        ls_object-clsname  = ls_impkey-clsname.
+        INSERT ls_object INTO TABLE wt_objects.
+      ENDIF.
+    ENDLOOP.
+  ENDMETHOD.
+
+
 method GET_COLOR_STYLE.
   DATA: ls_colors         TYPE zexcel_s_converter_col,
         ls_color_styles   TYPE ts_color_styles,
@@ -1118,6 +1153,29 @@ method GET_STYLE.
     ENDIF.
   ENDIF.
   endmethod.
+
+
+  METHOD get_subclasses.
+    DATA:
+      lt_subclasses TYPE seor_inheritance_keys.
+
+    CALL FUNCTION 'SEO_CLASS_GET_ALL_SUBS'
+      EXPORTING
+        clskey             = is_clskey
+      IMPORTING
+        inhkeys            = lt_subclasses
+      EXCEPTIONS
+        class_not_existing = 1
+        OTHERS             = 2.
+
+    CHECK sy-subrc = 0.
+
+    LOOP AT lt_subclasses INTO DATA(ls_subclass).
+      IF cl_abap_classdescr=>describe_by_name( ls_subclass-clsname )->is_instantiatable( ).
+        APPEND ls_subclass TO ct_classes.
+      ENDIF.
+    ENDLOOP.
+  ENDMETHOD.
 
 
 method INIT_OPTION.

--- a/src/zcl_excel_converter_alv_grid.clas.abap
+++ b/src/zcl_excel_converter_alv_grid.clas.abap
@@ -12,6 +12,8 @@ public section.
 *"* do not include other source files here!!!
   methods ZIF_EXCEL_CONVERTER~CREATE_FIELDCATALOG
     redefinition .
+  methods ZIF_EXCEL_CONVERTER~GET_SUPPORTED_CLASS
+    redefinition .
 protected section.
 *"* protected components of class ZCL_EXCEL_CONVERTER_ALV_GRID
 *"* do not include other source files here!!!
@@ -24,6 +26,10 @@ ENDCLASS.
 
 CLASS ZCL_EXCEL_CONVERTER_ALV_GRID IMPLEMENTATION.
 
+
+METHOD zif_excel_converter~get_supported_class.
+  rv_supported_class = 'CL_GUI_ALV_GRID'.
+ENDMETHOD.
 
 method ZIF_EXCEL_CONVERTER~CAN_CONVERT_OBJECT.
   data: lo_alv type REF TO cl_gui_alv_grid.

--- a/src/zcl_excel_converter_result_ex.clas.abap
+++ b/src/zcl_excel_converter_result_ex.clas.abap
@@ -12,6 +12,8 @@ public section.
     redefinition .
   methods ZIF_EXCEL_CONVERTER~CREATE_FIELDCATALOG
     redefinition .
+  methods zif_excel_converter~get_supported_class
+    REDEFINITION .
 *"* protected components of class ZCL_EXCEL_CONVERTER_RESULT_EX
 *"* do not include other source files here!!!
 *"* protected components of class ZCL_EXCEL_CONVERTER_RESULT_EX
@@ -28,6 +30,9 @@ ENDCLASS.
 
 CLASS ZCL_EXCEL_CONVERTER_RESULT_EX IMPLEMENTATION.
 
+METHOD ZIF_EXCEL_CONVERTER~GET_SUPPORTED_CLASS.
+  rv_supported_class = 'CL_SALV_EX_RESULT_DATA_TABLE'.
+ENDMETHOD.
 
 METHOD ZIF_EXCEL_CONVERTER~CAN_CONVERT_OBJECT.
 

--- a/src/zcl_excel_converter_result_wd.clas.abap
+++ b/src/zcl_excel_converter_result_wd.clas.abap
@@ -12,6 +12,8 @@ public section.
     redefinition .
   methods ZIF_EXCEL_CONVERTER~CREATE_FIELDCATALOG
     redefinition .
+  methods ZIF_EXCEL_CONVERTER~GET_SUPPORTED_CLASS
+    REDEFINITION .
 *"* protected components of class ZCL_EXCEL_CONVERTER_RESULT_WD
 *"* do not include other source files here!!!
 *"* protected components of class ZCL_EXCEL_CONVERTER_RESULT_WD
@@ -192,6 +194,9 @@ method GET_FIELDS_INFO.
 
   endmethod.
 
+METHOD ZIF_EXCEL_CONVERTER~GET_SUPPORTED_CLASS.
+  rv_supported_class = 'CL_SALV_WD_RESULT_DATA_TABLE'.
+ENDMETHOD.
 
 METHOD ZIF_EXCEL_CONVERTER~CAN_CONVERT_OBJECT.
 

--- a/src/zcl_excel_converter_salv_table.clas.abap
+++ b/src/zcl_excel_converter_salv_table.clas.abap
@@ -12,6 +12,8 @@ public section.
     redefinition .
   methods ZIF_EXCEL_CONVERTER~CREATE_FIELDCATALOG
     redefinition .
+  methods ZIF_EXCEL_CONVERTER~GET_SUPPORTED_CLASS
+    redefinition .
 *"* protected components of class ZCL_EXCEL_CONVERTER_SALV_TABLE
 *"* do not include other source files here!!!
 *"* protected components of class ZCL_EXCEL_CONVERTER_SALV_TABLE
@@ -206,6 +208,10 @@ method LOAD_DATA.
 
   endmethod.
 
+
+METHOD zif_excel_converter~get_supported_class.
+  rv_supported_class = 'CL_SALV_TABLE'.
+ENDMETHOD.
 
 METHOD zif_excel_converter~can_convert_object.
 

--- a/src/zif_excel_converter.intf.abap
+++ b/src/zif_excel_converter.intf.abap
@@ -20,4 +20,7 @@ INTERFACE zif_excel_converter
       !et_filter       TYPE zexcel_t_converter_fil
     RAISING
       zcx_excel .
+
+   METHODS get_supported_class
+     RETURNING VALUE(rv_supported_class) TYPE seoclsname.
 ENDINTERFACE.


### PR DESCRIPTION
Added method get_supported_class to ZIF_EXCEL_CONVERTER.

Implement your own converter by implementing this interface
and tell via the new interface method which class you support.

All instanceable implementations of the interface will be found
automatically.