### PR TITLE
Fix in demo 11: Field-symbol usage

### DIFF
--- a/src/demos/zdemo_excel11.prog.abap
+++ b/src/demos/zdemo_excel11.prog.abap
@@ -147,7 +147,7 @@ START-OF-SELECTION.
         ASSIGNING <relationship_address>
         WITH KEY standardaddress = 'X'.
 
-      IF <relationship_address> IS ASSIGNED.
+      IF sy-subrc = 0.
         " Read Relationship Address
         CLEAR addressdata.
         CALL FUNCTION 'BAPI_BUPA_ADDRESS_GETDETAIL'


### PR DESCRIPTION
Do not rely on IF ... IS ASSIGNED for a field symbol inside a LOOP