### PR TITLE
remove XFELD

### DIFF
--- a/src/demos/zdemo_excel15.prog.abap
+++ b/src/demos/zdemo_excel15.prog.abap
@@ -49,7 +49,7 @@ DATA:
 FIELD-SYMBOLS: <wa_files> TYPE t_demo_excel15.
 
 PARAMETERS: p_path  TYPE zexcel_export_dir,
-            p_noout TYPE xfeld DEFAULT abap_true.
+            p_noout TYPE abap_bool DEFAULT abap_true.
 
 
 AT SELECTION-SCREEN ON VALUE-REQUEST FOR p_path.

--- a/src/demos/zdemo_excel19.prog.abap
+++ b/src/demos/zdemo_excel19.prog.abap
@@ -17,7 +17,7 @@ DATA: lo_excel                  TYPE REF TO zcl_excel,
 CONSTANTS: gc_save_file_name TYPE string VALUE '19_SetActiveSheet.xlsx'.
 INCLUDE zdemo_excel_outputopt_incl.
 
-PARAMETERS: p_noout TYPE xfeld DEFAULT abap_true.
+PARAMETERS: p_noout TYPE abap_bool DEFAULT abap_true.
 
 
 START-OF-SELECTION.

--- a/src/zcl_excel.clas.abap
+++ b/src/zcl_excel.clas.abap
@@ -12,7 +12,7 @@ public section.
 
   data LEGACY_PALETTE type ref to ZCL_EXCEL_LEGACY_PALETTE read-only .
   data SECURITY type ref to ZCL_EXCEL_SECURITY .
-  data USE_TEMPLATE type XFELD .
+  data USE_TEMPLATE type ABAP_BOOL .
 
   methods ADD_NEW_AUTOFILTER
     importing

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -483,8 +483,8 @@ CLASS zcl_excel_worksheet DEFINITION
         !ip_table_title     TYPE string
         !ip_top_left_column TYPE zexcel_cell_column_alpha DEFAULT 'B'
         !ip_top_left_row    TYPE zexcel_cell_row DEFAULT 3
-        !ip_transpose       TYPE xfeld OPTIONAL
-        !ip_no_header       TYPE xfeld OPTIONAL
+        !ip_transpose       TYPE abap_bool OPTIONAL
+        !ip_no_header       TYPE abap_bool OPTIONAL
       RAISING
         zcx_excel .
     METHODS set_title


### PR DESCRIPTION
see https://github.com/sapmentors/abap2xlsx/issues/692

As a starting point, I've changed "xfeld" (as domain) to "abap_bool" in the source code;
I am unsure whether we also want to change the data elements (example, ZEXCEL_BOOK_PROTECTION) or not, just let me know and I can do that too.