### PR TITLE
remove usage of OS_BOOLEAN ( WIP #692 )

### DIFF
--- a/src/demos/zdemo_excel_outputopt_incl.prog.abap
+++ b/src/demos/zdemo_excel_outputopt_incl.prog.abap
@@ -302,7 +302,7 @@ CLASS lcl_output IMPLEMENTATION.
           t_mailtext           TYPE soli_tab,
           wa_mailtext          LIKE LINE OF t_mailtext,
           send_to              TYPE adr6-smtp_addr,
-          sent                 TYPE os_boolean.
+          sent                 TYPE abap_bool.
 
 
     mail_title     = 'Mail title'.
@@ -351,11 +351,11 @@ CLASS lcl_output IMPLEMENTATION.
 
         COMMIT WORK.
 
-        IF sent IS INITIAL.
-          MESSAGE i804(ZABAP2XLSX) WITH p_email.
-        ELSE.
+        IF sent = abap_true.
           MESSAGE s805(ZABAP2XLSX).
           MESSAGE 'Document ready to be sent - Check SOST or SCOT' TYPE 'I'.
+        ELSE.
+          MESSAGE i804(ZABAP2XLSX) WITH p_email.
         ENDIF.
 
       CATCH cx_bcs INTO bcs_exception.


### PR DESCRIPTION
I could find only one use of the OS_BOOLEAN DTEL in all of abap2xlsx, precisely in zdemo_excel_outputopt_incl where it is used for the return value of a standard class method, cl_send_request->send.

"send" calls "release" which calls "submit" which finally sets e_sent_to_all to X unless one recipient has issues, in which case it is cleared: for this reason, replacing "IS INITIAL" with "= abap_false" is incorrect and the test should be inverted.

WIP #692
