### PR TITLE
refactor method change_cell_style in zcl_excel_worksheet

### DIFF
--- a/src/zcl_excel_style_changer.clas.abap
+++ b/src/zcl_excel_style_changer.clas.abap
@@ -1,0 +1,1718 @@
+CLASS zcl_excel_style_changer DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+
+    INTERFACES zif_excel_style_changer.
+
+    CLASS-METHODS create
+      IMPORTING
+        excel         TYPE REF TO zcl_excel
+      RETURNING
+        VALUE(result) TYPE REF TO zif_excel_style_changer
+      RAISING
+        zcx_excel.
+
+*    CLASS-METHODS get
+*      IMPORTING
+*        excel         TYPE REF TO zcl_excel
+*      RETURNING
+*        VALUE(result) TYPE REF TO zif_excel_style_changer
+*      RAISING
+*        zcx_excel.
+*
+*    CLASS-METHODS get_from_guid
+*      IMPORTING
+*        excel         TYPE REF TO zcl_excel
+*        guid          TYPE zexcel_cell_style
+*      RETURNING
+*        VALUE(result) TYPE REF TO zif_excel_style_changer
+*      RAISING
+*        zcx_excel.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    METHODS clear_initial_colorxfields
+      IMPORTING
+        is_color  TYPE zexcel_s_style_color
+      CHANGING
+        cs_xcolor TYPE zexcel_s_cstylex_color.
+
+    METHODS move_supplied_borders
+      IMPORTING
+        iv_border_supplied        TYPE abap_bool
+        is_border                 TYPE zexcel_s_cstyle_border
+        iv_xborder_supplied       TYPE abap_bool
+        is_xborder                TYPE zexcel_s_cstylex_border
+      CHANGING
+        cs_complete_style_border  TYPE zexcel_s_cstyle_border
+        cs_complete_stylex_border TYPE zexcel_s_cstylex_border.
+
+    DATA: excel                   TYPE REF TO zcl_excel,
+          lv_xborder_supplied     TYPE abap_bool,
+          single_change_requested TYPE zexcel_s_cstylex_complete,
+          BEGIN OF multiple_change_requested,
+            complete   TYPE abap_bool,
+            font       TYPE abap_bool,
+            fill       TYPE abap_bool,
+            BEGIN OF borders,
+              complete   TYPE abap_bool,
+              allborders TYPE abap_bool,
+              diagonal   TYPE abap_bool,
+              down       TYPE abap_bool,
+              left       TYPE abap_bool,
+              right      TYPE abap_bool,
+              top        TYPE abap_bool,
+            END OF borders,
+            alignment  TYPE abap_bool,
+            protection TYPE abap_bool,
+          END OF multiple_change_requested.
+    CONSTANTS:
+          lv_border_supplied  TYPE abap_bool VALUE abap_true.
+    ALIASES:
+          complete_style   FOR zif_excel_style_changer~complete_style,
+          complete_stylex  FOR zif_excel_style_changer~complete_stylex.
+
+ENDCLASS.
+
+
+
+CLASS zcl_excel_style_changer IMPLEMENTATION.
+
+
+  METHOD clear_initial_colorxfields.
+
+    IF is_color-rgb IS INITIAL.
+      CLEAR cs_xcolor-rgb.
+    ENDIF.
+    IF is_color-indexed IS INITIAL.
+      CLEAR cs_xcolor-indexed.
+    ENDIF.
+    IF is_color-theme IS INITIAL.
+      CLEAR cs_xcolor-theme.
+    ENDIF.
+    IF is_color-tint IS INITIAL.
+      CLEAR cs_xcolor-tint.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD create.
+
+    DATA: style TYPE REF TO zcl_excel_style_changer.
+
+    CREATE OBJECT style.
+    style->excel = excel.
+    result = style.
+
+*  ENDMETHOD.
+*
+*
+*  METHOD get.
+*
+*    DATA: style TYPE REF TO zcl_excel_style_changer.
+*
+*    CREATE OBJECT style.
+*    style->excel = excel.
+*    result = style.
+*
+*  ENDMETHOD.
+*
+*
+*  METHOD get_from_guid.
+*
+*    DATA: style TYPE REF TO zcl_excel_style_changer.
+*
+*    DATA(stylemapping) = excel->get_style_to_guid( guid ).
+*    CREATE OBJECT style.
+*    style->excel = excel.
+*    style->complete_style = stylemapping-complete_style.
+*    style->complete_stylex = stylemapping-complete_stylex.
+*
+*    result = style.
+
+  ENDMETHOD.
+
+
+  METHOD move_supplied_borders.
+
+    DATA: cs_borderx TYPE zexcel_s_cstylex_border.
+
+    IF iv_border_supplied = abap_true.  " only act if parameter was supplied
+      IF iv_xborder_supplied = abap_true. "
+        cs_borderx = is_xborder.             " use supplied x-parameter
+      ELSE.
+        CLEAR cs_borderx WITH 'X'. " <============================== DDIC structure enh. category to set?
+        " clear in a way that would be expected to work easily
+        IF is_border-border_style IS  INITIAL.
+          CLEAR cs_borderx-border_style.
+        ENDIF.
+        clear_initial_colorxfields(
+          EXPORTING
+            is_color  = is_border-border_color
+          CHANGING
+            cs_xcolor = cs_borderx-border_color ).
+      ENDIF.
+      cs_complete_style_border = is_border.
+      cs_complete_stylex_border = cs_borderx.
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~apply.
+
+    DATA: stylemapping TYPE zexcel_s_stylemapping,
+          lo_worksheet TYPE REF TO zcl_excel_worksheet,
+          l_guid       TYPE zexcel_cell_style.
+
+    lo_worksheet = excel->get_worksheet_by_name( ip_sheet_name = ip_worksheet->get_title( ) ).
+    IF lo_worksheet <> ip_worksheet.
+      zcx_excel=>raise_text( 'Worksheet doesn''t correspond to workbook of style changer'(001) ).
+    ENDIF.
+
+    TRY.
+        ip_worksheet->get_cell( EXPORTING ip_column = ip_column
+                                          ip_row    = ip_row
+                                IMPORTING ep_guid   = l_guid ).
+        stylemapping = excel->get_style_to_guid( l_guid ).
+      CATCH zcx_excel.
+* Error --> use submitted style
+    ENDTRY.
+
+
+    IF multiple_change_requested-complete = abap_true.
+      stylemapping-complete_style = complete_style.
+      stylemapping-complete_stylex = complete_stylex.
+    ENDIF.
+
+    IF multiple_change_requested-font = abap_true.
+      stylemapping-complete_style-font = complete_style-font.
+      stylemapping-complete_stylex-font = complete_stylex-font.
+    ENDIF.
+
+    IF multiple_change_requested-fill = abap_true.
+      stylemapping-complete_style-fill = complete_style-fill.
+      stylemapping-complete_stylex-fill = complete_stylex-fill.
+    ENDIF.
+
+    IF multiple_change_requested-borders-complete = abap_true.
+      stylemapping-complete_style-borders = complete_style-borders.
+      stylemapping-complete_stylex-borders = complete_stylex-borders.
+    ENDIF.
+
+    IF multiple_change_requested-borders-allborders = abap_true.
+      stylemapping-complete_style-borders-allborders = complete_style-borders-allborders.
+      stylemapping-complete_stylex-borders-allborders = complete_stylex-borders-allborders.
+    ENDIF.
+
+    IF multiple_change_requested-borders-diagonal = abap_true.
+      stylemapping-complete_style-borders-diagonal = complete_style-borders-diagonal.
+      stylemapping-complete_stylex-borders-diagonal = complete_stylex-borders-diagonal.
+    ENDIF.
+
+    IF multiple_change_requested-borders-down = abap_true.
+      stylemapping-complete_style-borders-down = complete_style-borders-down.
+      stylemapping-complete_stylex-borders-down = complete_stylex-borders-down.
+    ENDIF.
+
+    IF multiple_change_requested-borders-left = abap_true.
+      stylemapping-complete_style-borders-left = complete_style-borders-left.
+      stylemapping-complete_stylex-borders-left = complete_stylex-borders-left.
+    ENDIF.
+
+    IF multiple_change_requested-borders-right = abap_true.
+      stylemapping-complete_style-borders-right = complete_style-borders-right.
+      stylemapping-complete_stylex-borders-right = complete_stylex-borders-right.
+    ENDIF.
+
+    IF multiple_change_requested-borders-TOP = abap_true.
+      stylemapping-complete_style-borders-TOP = complete_style-borders-TOP.
+      stylemapping-complete_stylex-borders-TOP = complete_stylex-borders-TOP.
+    ENDIF.
+
+    IF multiple_change_requested-alignment = abap_true.
+      stylemapping-complete_style-alignment = complete_style-alignment.
+      stylemapping-complete_stylex-alignment = complete_stylex-alignment.
+    ENDIF.
+
+    IF multiple_change_requested-protection = abap_true.
+      stylemapping-complete_style-protection = complete_style-protection.
+      stylemapping-complete_stylex-protection = complete_stylex-protection.
+    ENDIF.
+
+    IF complete_stylex-number_format = abap_true.
+      stylemapping-complete_style-number_format-format_code = complete_style-number_format-format_code.
+      stylemapping-complete_stylex-number_format-format_code = abap_true.
+    ENDIF.
+    IF complete_stylex-font-bold = abap_true.
+      stylemapping-complete_style-font-bold = complete_style-font-bold.
+      stylemapping-complete_stylex-font-bold = complete_stylex-font-bold.
+    ENDIF.
+    IF complete_stylex-font-color = abap_true.
+      stylemapping-complete_style-font-color = complete_style-font-color.
+      stylemapping-complete_stylex-font-color = complete_stylex-font-color.
+    ENDIF.
+    IF complete_stylex-font-color-rgb = abap_true.
+      stylemapping-complete_style-font-color-rgb = complete_style-font-color-rgb.
+      stylemapping-complete_stylex-font-color-rgb = complete_stylex-font-color-rgb.
+    ENDIF.
+    IF complete_stylex-font-color-indexed = abap_true.
+      stylemapping-complete_style-font-color-indexed = complete_style-font-color-indexed.
+      stylemapping-complete_stylex-font-color-indexed = complete_stylex-font-color-indexed.
+    ENDIF.
+    IF complete_stylex-font-color-theme = abap_true.
+      stylemapping-complete_style-font-color-theme = complete_style-font-color-theme.
+      stylemapping-complete_stylex-font-color-theme = complete_stylex-font-color-theme.
+    ENDIF.
+    IF complete_stylex-font-color-tint = abap_true.
+      stylemapping-complete_style-font-color-tint = complete_style-font-color-tint.
+      stylemapping-complete_stylex-font-color-tint = complete_stylex-font-color-tint.
+    ENDIF.
+    IF complete_stylex-font-family = abap_true.
+      stylemapping-complete_style-font-family = complete_style-font-family.
+      stylemapping-complete_stylex-font-family = complete_stylex-font-family.
+    ENDIF.
+    IF complete_stylex-font-italic = abap_true.
+      stylemapping-complete_style-font-italic = complete_style-font-italic.
+      stylemapping-complete_stylex-font-italic = complete_stylex-font-italic.
+    ENDIF.
+    IF complete_stylex-font-name = abap_true.
+      stylemapping-complete_style-font-name = complete_style-font-name.
+      stylemapping-complete_stylex-font-name = complete_stylex-font-name.
+    ENDIF.
+    IF complete_stylex-font-scheme = abap_true.
+      stylemapping-complete_style-font-scheme = complete_style-font-scheme.
+      stylemapping-complete_stylex-font-scheme = complete_stylex-font-scheme.
+    ENDIF.
+    IF complete_stylex-font-size = abap_true.
+      stylemapping-complete_style-font-size = complete_style-font-size.
+      stylemapping-complete_stylex-font-size = complete_stylex-font-size.
+    ENDIF.
+    IF complete_stylex-font-strikethrough = abap_true.
+      stylemapping-complete_style-font-strikethrough = complete_style-font-strikethrough.
+      stylemapping-complete_stylex-font-strikethrough = complete_stylex-font-strikethrough.
+    ENDIF.
+    IF complete_stylex-font-underline = abap_true.
+      stylemapping-complete_style-font-underline = complete_style-font-underline.
+      stylemapping-complete_stylex-font-underline = complete_stylex-font-underline.
+    ENDIF.
+    IF complete_stylex-font-underline_mode = abap_true.
+      stylemapping-complete_style-font-underline_mode = complete_style-font-underline_mode.
+      stylemapping-complete_stylex-font-underline_mode = complete_stylex-font-underline_mode.
+    ENDIF.
+
+    IF complete_stylex-fill-filltype = abap_true.
+      stylemapping-complete_style-fill-filltype = complete_style-fill-filltype.
+      stylemapping-complete_stylex-fill-filltype = complete_stylex-fill-filltype.
+    ENDIF.
+    IF complete_stylex-fill-rotation = abap_true.
+      stylemapping-complete_style-fill-rotation = complete_style-fill-rotation.
+      stylemapping-complete_stylex-fill-rotation = complete_stylex-fill-rotation.
+    ENDIF.
+    IF complete_stylex-fill-fgcolor = abap_true.
+      stylemapping-complete_style-fill-fgcolor = complete_style-fill-fgcolor.
+      stylemapping-complete_stylex-fill-fgcolor = complete_stylex-fill-fgcolor.
+    ENDIF.
+    IF complete_stylex-fill-fgcolor-rgb = abap_true.
+      stylemapping-complete_style-fill-fgcolor-rgb = complete_style-fill-fgcolor-rgb.
+      stylemapping-complete_stylex-fill-fgcolor-rgb = complete_stylex-fill-fgcolor-rgb.
+    ENDIF.
+    IF complete_stylex-fill-fgcolor-indexed = abap_true.
+      stylemapping-complete_style-fill-fgcolor-indexed = complete_style-fill-fgcolor-indexed.
+      stylemapping-complete_stylex-fill-fgcolor-indexed = complete_stylex-fill-fgcolor-indexed.
+    ENDIF.
+    IF complete_stylex-fill-fgcolor-theme = abap_true.
+      stylemapping-complete_style-fill-fgcolor-theme = complete_style-fill-fgcolor-theme.
+      stylemapping-complete_stylex-fill-fgcolor-theme = complete_stylex-fill-fgcolor-theme.
+    ENDIF.
+    IF complete_stylex-fill-fgcolor-tint = abap_true.
+      stylemapping-complete_style-fill-fgcolor-tint = complete_style-fill-fgcolor-tint.
+      stylemapping-complete_stylex-fill-fgcolor-tint = complete_stylex-fill-fgcolor-tint.
+    ENDIF.
+
+    IF complete_stylex-fill-bgcolor = abap_true.
+      stylemapping-complete_style-fill-bgcolor = complete_style-fill-bgcolor.
+      stylemapping-complete_stylex-fill-bgcolor = complete_stylex-fill-bgcolor.
+    ENDIF.
+    IF complete_stylex-fill-bgcolor-rgb = abap_true.
+      stylemapping-complete_style-fill-bgcolor-rgb = complete_style-fill-bgcolor-rgb.
+      stylemapping-complete_stylex-fill-bgcolor-rgb = complete_stylex-fill-bgcolor-rgb.
+    ENDIF.
+    IF complete_stylex-fill-bgcolor-indexed = abap_true.
+      stylemapping-complete_style-fill-bgcolor-indexed = complete_style-fill-bgcolor-indexed.
+      stylemapping-complete_stylex-fill-bgcolor-indexed = complete_stylex-fill-bgcolor-indexed.
+    ENDIF.
+    IF complete_stylex-fill-bgcolor-theme = abap_true.
+      stylemapping-complete_style-fill-bgcolor-theme = complete_style-fill-bgcolor-theme.
+      stylemapping-complete_stylex-fill-bgcolor-theme = complete_stylex-fill-bgcolor-theme.
+    ENDIF.
+    IF complete_stylex-fill-bgcolor-tint = abap_true.
+      stylemapping-complete_style-fill-bgcolor-tint = complete_style-fill-bgcolor-tint.
+      stylemapping-complete_stylex-fill-bgcolor-tint = complete_stylex-fill-bgcolor-tint.
+    ENDIF.
+
+    IF complete_stylex-fill-gradtype-type = abap_true.
+      stylemapping-complete_style-fill-gradtype-type = complete_style-fill-gradtype-type.
+      stylemapping-complete_stylex-fill-gradtype-type = complete_stylex-fill-gradtype-type.
+    ENDIF.
+    IF complete_stylex-fill-gradtype-degree = abap_true.
+      stylemapping-complete_style-fill-gradtype-degree = complete_style-fill-gradtype-degree.
+      stylemapping-complete_stylex-fill-gradtype-degree = complete_stylex-fill-gradtype-degree.
+    ENDIF.
+    IF complete_stylex-fill-gradtype-bottom = abap_true.
+      stylemapping-complete_style-fill-gradtype-bottom = complete_style-fill-gradtype-bottom.
+      stylemapping-complete_stylex-fill-gradtype-bottom = complete_stylex-fill-gradtype-bottom.
+    ENDIF.
+    IF complete_stylex-fill-gradtype-left = abap_true.
+      stylemapping-complete_style-fill-gradtype-left = complete_style-fill-gradtype-left.
+      stylemapping-complete_stylex-fill-gradtype-left = complete_stylex-fill-gradtype-left.
+    ENDIF.
+    IF complete_stylex-fill-gradtype-top = abap_true.
+      stylemapping-complete_style-fill-gradtype-top = complete_style-fill-gradtype-top.
+      stylemapping-complete_stylex-fill-gradtype-top = complete_stylex-fill-gradtype-top.
+    ENDIF.
+    IF complete_stylex-fill-gradtype-right = abap_true.
+      stylemapping-complete_style-fill-gradtype-right = complete_style-fill-gradtype-right.
+      stylemapping-complete_stylex-fill-gradtype-right = complete_stylex-fill-gradtype-right.
+    ENDIF.
+    IF complete_stylex-fill-gradtype-position1 = abap_true.
+      stylemapping-complete_style-fill-gradtype-position1 = complete_style-fill-gradtype-position1.
+      stylemapping-complete_stylex-fill-gradtype-position1 = complete_stylex-fill-gradtype-position1.
+    ENDIF.
+    IF complete_stylex-fill-gradtype-position2 = abap_true.
+      stylemapping-complete_style-fill-gradtype-position2 = complete_style-fill-gradtype-position2.
+      stylemapping-complete_stylex-fill-gradtype-position2 = complete_stylex-fill-gradtype-position2.
+    ENDIF.
+    IF complete_stylex-fill-gradtype-position3 = abap_true.
+      stylemapping-complete_style-fill-gradtype-position3 = complete_style-fill-gradtype-position3.
+      stylemapping-complete_stylex-fill-gradtype-position3 = complete_stylex-fill-gradtype-position3.
+    ENDIF.
+
+
+
+    IF complete_stylex-borders-diagonal_mode = abap_true.
+      stylemapping-complete_style-borders-diagonal_mode = complete_style-borders-diagonal_mode.
+      stylemapping-complete_stylex-borders-diagonal_mode = complete_stylex-borders-diagonal_mode.
+    ENDIF.
+    IF complete_stylex-alignment-horizontal = abap_true.
+      stylemapping-complete_style-alignment-horizontal = complete_style-alignment-horizontal.
+      stylemapping-complete_stylex-alignment-horizontal = complete_stylex-alignment-horizontal.
+    ENDIF.
+    IF complete_stylex-alignment-vertical = abap_true.
+      stylemapping-complete_style-alignment-vertical = complete_style-alignment-vertical.
+      stylemapping-complete_stylex-alignment-vertical = complete_stylex-alignment-vertical.
+    ENDIF.
+    IF complete_stylex-alignment-textrotation = abap_true.
+      stylemapping-complete_style-alignment-textrotation = complete_style-alignment-textrotation.
+      stylemapping-complete_stylex-alignment-textrotation = complete_stylex-alignment-textrotation.
+    ENDIF.
+    IF complete_stylex-alignment-wraptext = abap_true.
+      stylemapping-complete_style-alignment-wraptext = complete_style-alignment-wraptext.
+      stylemapping-complete_stylex-alignment-wraptext = complete_stylex-alignment-wraptext.
+    ENDIF.
+    IF complete_stylex-alignment-shrinktofit = abap_true.
+      stylemapping-complete_style-alignment-shrinktofit = complete_style-alignment-shrinktofit.
+      stylemapping-complete_stylex-alignment-shrinktofit = complete_stylex-alignment-shrinktofit.
+    ENDIF.
+    IF complete_stylex-alignment-indent = abap_true.
+      stylemapping-complete_style-alignment-indent = complete_style-alignment-indent.
+      stylemapping-complete_stylex-alignment-indent = complete_stylex-alignment-indent.
+    ENDIF.
+    IF complete_stylex-protection-hidden = abap_true.
+      stylemapping-complete_style-protection-hidden = complete_style-protection-hidden.
+      stylemapping-complete_stylex-protection-hidden = complete_stylex-protection-hidden.
+    ENDIF.
+    IF complete_stylex-protection-locked = abap_true.
+      stylemapping-complete_style-protection-locked = complete_style-protection-locked.
+      stylemapping-complete_stylex-protection-locked = complete_stylex-protection-locked.
+    ENDIF.
+
+    IF complete_stylex-borders-allborders-border_style = abap_true.
+      stylemapping-complete_style-borders-allborders-border_style = complete_style-borders-allborders-border_style.
+      stylemapping-complete_stylex-borders-allborders-border_style = complete_stylex-borders-allborders-border_style.
+    ENDIF.
+    IF complete_stylex-borders-allborders-border_color-rgb = abap_true.
+      stylemapping-complete_style-borders-allborders-border_color-rgb = complete_style-borders-allborders-border_color-rgb.
+      stylemapping-complete_stylex-borders-allborders-border_color-rgb = complete_stylex-borders-allborders-border_color-rgb.
+    ENDIF.
+    IF complete_stylex-borders-allborders-border_color-indexed = abap_true.
+      stylemapping-complete_style-borders-allborders-border_color-indexed = complete_style-borders-allborders-border_color-indexed.
+      stylemapping-complete_stylex-borders-allborders-border_color-indexed = complete_stylex-borders-allborders-border_color-indexed.
+    ENDIF.
+    IF complete_stylex-borders-allborders-border_color-theme = abap_true.
+      stylemapping-complete_style-borders-allborders-border_color-theme = complete_style-borders-allborders-border_color-theme.
+      stylemapping-complete_stylex-borders-allborders-border_color-theme = complete_stylex-borders-allborders-border_color-theme.
+    ENDIF.
+    IF complete_stylex-borders-allborders-border_color-tint = abap_true.
+      stylemapping-complete_style-borders-allborders-border_color-tint = complete_style-borders-allborders-border_color-tint.
+      stylemapping-complete_stylex-borders-allborders-border_color-tint = complete_stylex-borders-allborders-border_color-tint.
+    ENDIF.
+
+    IF complete_stylex-borders-diagonal-border_style = abap_true.
+      stylemapping-complete_style-borders-diagonal-border_style = complete_style-borders-diagonal-border_style.
+      stylemapping-complete_stylex-borders-diagonal-border_style = complete_stylex-borders-diagonal-border_style.
+    ENDIF.
+    IF complete_stylex-borders-diagonal-border_color-rgb = abap_true.
+      stylemapping-complete_style-borders-diagonal-border_color-rgb = complete_style-borders-diagonal-border_color-rgb.
+      stylemapping-complete_stylex-borders-diagonal-border_color-rgb = complete_stylex-borders-diagonal-border_color-rgb.
+    ENDIF.
+    IF complete_stylex-borders-diagonal-border_color-indexed = abap_true.
+      stylemapping-complete_style-borders-diagonal-border_color-indexed = complete_style-borders-diagonal-border_color-indexed.
+      stylemapping-complete_stylex-borders-diagonal-border_color-indexed = complete_stylex-borders-diagonal-border_color-indexed.
+    ENDIF.
+    IF complete_stylex-borders-diagonal-border_color-theme = abap_true.
+      stylemapping-complete_style-borders-diagonal-border_color-theme = complete_style-borders-diagonal-border_color-theme.
+      stylemapping-complete_stylex-borders-diagonal-border_color-theme = complete_stylex-borders-diagonal-border_color-theme.
+    ENDIF.
+    IF complete_stylex-borders-diagonal-border_color-tint = abap_true.
+      stylemapping-complete_style-borders-diagonal-border_color-tint = complete_style-borders-diagonal-border_color-tint.
+      stylemapping-complete_stylex-borders-diagonal-border_color-tint = complete_stylex-borders-diagonal-border_color-tint.
+    ENDIF.
+
+    IF complete_stylex-borders-down-border_style = abap_true.
+      stylemapping-complete_style-borders-down-border_style = complete_style-borders-down-border_style.
+      stylemapping-complete_stylex-borders-down-border_style = complete_stylex-borders-down-border_style.
+    ENDIF.
+    IF complete_stylex-borders-down-border_color-rgb = abap_true.
+      stylemapping-complete_style-borders-down-border_color-rgb = complete_style-borders-down-border_color-rgb.
+      stylemapping-complete_stylex-borders-down-border_color-rgb = complete_stylex-borders-down-border_color-rgb.
+    ENDIF.
+    IF complete_stylex-borders-down-border_color-indexed = abap_true.
+      stylemapping-complete_style-borders-down-border_color-indexed = complete_style-borders-down-border_color-indexed.
+      stylemapping-complete_stylex-borders-down-border_color-indexed = complete_stylex-borders-down-border_color-indexed.
+    ENDIF.
+    IF complete_stylex-borders-down-border_color-theme = abap_true.
+      stylemapping-complete_style-borders-down-border_color-theme = complete_style-borders-down-border_color-theme.
+      stylemapping-complete_stylex-borders-down-border_color-theme = complete_stylex-borders-down-border_color-theme.
+    ENDIF.
+    IF complete_stylex-borders-down-border_color-tint = abap_true.
+      stylemapping-complete_style-borders-down-border_color-tint = complete_style-borders-down-border_color-tint.
+      stylemapping-complete_stylex-borders-down-border_color-tint = complete_stylex-borders-down-border_color-tint.
+    ENDIF.
+
+    IF complete_stylex-borders-left-border_style = abap_true.
+      stylemapping-complete_style-borders-left-border_style = complete_style-borders-left-border_style.
+      stylemapping-complete_stylex-borders-left-border_style = complete_stylex-borders-left-border_style.
+    ENDIF.
+    IF complete_stylex-borders-left-border_color-rgb = abap_true.
+      stylemapping-complete_style-borders-left-border_color-rgb = complete_style-borders-left-border_color-rgb.
+      stylemapping-complete_stylex-borders-left-border_color-rgb = complete_stylex-borders-left-border_color-rgb.
+    ENDIF.
+    IF complete_stylex-borders-left-border_color-indexed = abap_true.
+      stylemapping-complete_style-borders-left-border_color-indexed = complete_style-borders-left-border_color-indexed.
+      stylemapping-complete_stylex-borders-left-border_color-indexed = complete_stylex-borders-left-border_color-indexed.
+    ENDIF.
+    IF complete_stylex-borders-left-border_color-theme = abap_true.
+      stylemapping-complete_style-borders-left-border_color-theme = complete_style-borders-left-border_color-theme.
+      stylemapping-complete_stylex-borders-left-border_color-theme = complete_stylex-borders-left-border_color-theme.
+    ENDIF.
+    IF complete_stylex-borders-left-border_color-tint = abap_true.
+      stylemapping-complete_style-borders-left-border_color-tint = complete_style-borders-left-border_color-tint.
+      stylemapping-complete_stylex-borders-left-border_color-tint = complete_stylex-borders-left-border_color-tint.
+    ENDIF.
+
+    IF complete_stylex-borders-right-border_style = abap_true.
+      stylemapping-complete_style-borders-right-border_style = complete_style-borders-right-border_style.
+      stylemapping-complete_stylex-borders-right-border_style = complete_stylex-borders-right-border_style.
+    ENDIF.
+    IF complete_stylex-borders-right-border_color-rgb = abap_true.
+      stylemapping-complete_style-borders-right-border_color-rgb = complete_style-borders-right-border_color-rgb.
+      stylemapping-complete_stylex-borders-right-border_color-rgb = complete_stylex-borders-right-border_color-rgb.
+    ENDIF.
+    IF complete_stylex-borders-right-border_color-indexed = abap_true.
+      stylemapping-complete_style-borders-right-border_color-indexed = complete_style-borders-right-border_color-indexed.
+      stylemapping-complete_stylex-borders-right-border_color-indexed = complete_stylex-borders-right-border_color-indexed.
+    ENDIF.
+    IF complete_stylex-borders-right-border_color-theme = abap_true.
+      stylemapping-complete_style-borders-right-border_color-theme = complete_style-borders-right-border_color-theme.
+      stylemapping-complete_stylex-borders-right-border_color-theme = complete_stylex-borders-right-border_color-theme.
+    ENDIF.
+    IF complete_stylex-borders-right-border_color-tint = abap_true.
+      stylemapping-complete_style-borders-right-border_color-tint = complete_style-borders-right-border_color-tint.
+      stylemapping-complete_stylex-borders-right-border_color-tint = complete_stylex-borders-right-border_color-tint.
+    ENDIF.
+
+    IF complete_stylex-borders-top-border_style = abap_true.
+      stylemapping-complete_style-borders-top-border_style = complete_style-borders-top-border_style.
+      stylemapping-complete_stylex-borders-top-border_style = complete_stylex-borders-top-border_style.
+    ENDIF.
+    IF complete_stylex-borders-top-border_color-rgb = abap_true.
+      stylemapping-complete_style-borders-top-border_color-rgb = complete_style-borders-top-border_color-rgb.
+      stylemapping-complete_stylex-borders-top-border_color-rgb = complete_stylex-borders-top-border_color-rgb.
+    ENDIF.
+    IF complete_stylex-borders-top-border_color-indexed = abap_true.
+      stylemapping-complete_style-borders-top-border_color-indexed = complete_style-borders-top-border_color-indexed.
+      stylemapping-complete_stylex-borders-top-border_color-indexed = complete_stylex-borders-top-border_color-indexed.
+    ENDIF.
+    IF complete_stylex-borders-top-border_color-theme = abap_true.
+      stylemapping-complete_style-borders-top-border_color-theme = complete_style-borders-top-border_color-theme.
+      stylemapping-complete_stylex-borders-top-border_color-theme = complete_stylex-borders-top-border_color-theme.
+    ENDIF.
+    IF complete_stylex-borders-top-border_color-tint = abap_true.
+      stylemapping-complete_style-borders-top-border_color-tint = complete_style-borders-top-border_color-tint.
+      stylemapping-complete_stylex-borders-top-border_color-tint = complete_stylex-borders-top-border_color-tint.
+    ENDIF.
+
+
+* Now we have a completly filled styles.
+* This can be used to get the guid
+* Return guid if requested.  Might be used if copy&paste of styles is requested
+    l_guid = me->excel->get_static_cellstyle_guid( ip_cstyle_complete  = stylemapping-complete_style
+                                                   ip_cstylex_complete = stylemapping-complete_stylex  ).
+    lo_worksheet->set_cell_style( ip_column = ip_column
+                                  ip_row    = ip_row
+                                  ip_style  = l_guid ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~get_guid.
+
+    result = excel->get_static_cellstyle_guid( ip_cstyle_complete  = complete_style
+                                               ip_cstylex_complete = complete_stylex  ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_size.
+
+    complete_style-font-size = value.
+    complete_stylex-font-size = abap_true.
+    single_change_requested-font-size = abap_true.
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_number_format.
+
+    complete_style-number_format-format_code = value.
+    complete_stylex-number_format-format_code = abap_true.
+    single_change_requested-number_format-format_code = abap_true.
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_complete.
+
+    complete_style = ip_complete.
+    complete_stylex = ip_xcomplete.
+    multiple_change_requested-complete = abap_true.
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_complete_font.
+
+    DATA: fontx TYPE zexcel_s_cstylex_font.
+
+    IF ip_xfont IS SUPPLIED.
+      fontx = ip_xfont.
+    ELSE.
+* Only supplied values should be used - exception: Flags bold and italic strikethrough underline
+      MOVE 'X' TO: fontx-bold,
+                   fontx-italic,
+                   fontx-strikethrough,
+                   fontx-underline_mode.
+      CLEAR fontx-color WITH 'X'.
+      clear_initial_colorxfields(
+        EXPORTING
+          is_color  = ip_font-color
+        CHANGING
+          cs_xcolor = fontx-color ).
+      IF ip_font-family IS NOT INITIAL.
+        fontx-family = 'X'.
+      ENDIF.
+      IF ip_font-name IS NOT INITIAL.
+        fontx-name = 'X'.
+      ENDIF.
+      IF ip_font-scheme IS NOT INITIAL.
+        fontx-scheme = 'X'.
+      ENDIF.
+      IF ip_font-size IS NOT INITIAL.
+        fontx-size = 'X'.
+      ENDIF.
+      IF ip_font-underline_mode IS NOT INITIAL.
+        fontx-underline_mode = 'X'.
+      ENDIF.
+    ENDIF.
+
+    complete_style-font = ip_font.
+    complete_stylex-font = fontx.
+    multiple_change_requested-font = abap_true.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_complete_fill.
+
+    DATA: fillx LIKE ip_xfill.
+    IF ip_xfill IS SUPPLIED.
+      fillx = ip_xfill.
+    ELSE.
+      CLEAR fillx WITH 'X'.
+      IF ip_fill-filltype IS INITIAL.
+        CLEAR fillx-filltype.
+      ENDIF.
+      clear_initial_colorxfields(
+        EXPORTING
+          is_color  = ip_fill-fgcolor
+        CHANGING
+          cs_xcolor = fillx-fgcolor ).
+      clear_initial_colorxfields(
+        EXPORTING
+          is_color  = ip_fill-bgcolor
+        CHANGING
+          cs_xcolor = fillx-bgcolor ).
+
+    ENDIF.
+
+    complete_style-fill = ip_fill.
+    complete_stylex-fill = fillx.
+    multiple_change_requested-fill = abap_true.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_complete_borders.
+
+    DATA: bordersx LIKE ip_xborders.
+    IF ip_xborders IS SUPPLIED.
+      bordersx = ip_xborders.
+    ELSE.
+      CLEAR bordersx WITH 'X'.
+      IF ip_borders-allborders-border_style IS INITIAL.
+        CLEAR bordersx-allborders-border_style.
+      ENDIF.
+      IF ip_borders-diagonal-border_style IS INITIAL.
+        CLEAR bordersx-diagonal-border_style.
+      ENDIF.
+      IF ip_borders-down-border_style IS INITIAL.
+        CLEAR bordersx-down-border_style.
+      ENDIF.
+      IF ip_borders-left-border_style IS INITIAL.
+        CLEAR bordersx-left-border_style.
+      ENDIF.
+      IF ip_borders-right-border_style IS INITIAL.
+        CLEAR bordersx-right-border_style.
+      ENDIF.
+      IF ip_borders-top-border_style IS INITIAL.
+        CLEAR bordersx-top-border_style.
+      ENDIF.
+
+      clear_initial_colorxfields(
+        EXPORTING
+          is_color  = ip_borders-allborders-border_color
+        CHANGING
+          cs_xcolor = bordersx-allborders-border_color ).
+
+      clear_initial_colorxfields(
+        EXPORTING
+          is_color  = ip_borders-diagonal-border_color
+        CHANGING
+          cs_xcolor = bordersx-diagonal-border_color ).
+
+      clear_initial_colorxfields(
+        EXPORTING
+          is_color  = ip_borders-down-border_color
+        CHANGING
+          cs_xcolor = bordersx-down-border_color ).
+
+      clear_initial_colorxfields(
+        EXPORTING
+          is_color  = ip_borders-left-border_color
+        CHANGING
+          cs_xcolor = bordersx-left-border_color ).
+
+      clear_initial_colorxfields(
+        EXPORTING
+          is_color  = ip_borders-right-border_color
+        CHANGING
+          cs_xcolor = bordersx-right-border_color ).
+
+      clear_initial_colorxfields(
+        EXPORTING
+          is_color  = ip_borders-top-border_color
+        CHANGING
+          cs_xcolor = bordersx-top-border_color ).
+
+    ENDIF.
+
+    complete_style-borders = ip_borders.
+    complete_stylex-borders = bordersx.
+    multiple_change_requested-borders-complete = abap_true.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_complete_alignment.
+
+    DATA: alignmentx LIKE ip_xalignment.
+
+    IF ip_xalignment IS SUPPLIED.
+      alignmentx = ip_xalignment.
+    ELSE.
+      CLEAR alignmentx WITH 'X'.
+      IF ip_alignment-horizontal IS INITIAL.
+        CLEAR alignmentx-horizontal.
+      ENDIF.
+      IF ip_alignment-vertical IS INITIAL.
+        CLEAR alignmentx-vertical.
+      ENDIF.
+    ENDIF.
+
+    complete_style-alignment  = ip_alignment .
+    complete_stylex-alignment = alignmentx   .
+    multiple_change_requested-alignment = abap_true.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_complete_protection.
+
+    MOVE-CORRESPONDING ip_protection  TO complete_style-protection.
+    IF ip_xprotection IS SUPPLIED.
+      MOVE-CORRESPONDING ip_xprotection TO complete_stylex-protection.
+    ELSE.
+      IF ip_protection-hidden IS NOT INITIAL.
+        complete_stylex-protection-hidden = 'X'.
+      ENDIF.
+      IF ip_protection-locked IS NOT INITIAL.
+        complete_stylex-protection-locked = 'X'.
+      ENDIF.
+    ENDIF.
+    multiple_change_requested-protection = abap_true.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_complete_borders_all.
+
+*    lv_border_supplied = boolc( ip_borders_allborders IS SUPPLIED ).
+    lv_xborder_supplied = boolc( ip_xborders_allborders IS SUPPLIED ).
+    move_supplied_borders(
+      EXPORTING
+        iv_border_supplied        = lv_border_supplied
+        is_border                 = ip_borders_allborders
+        iv_xborder_supplied       = lv_xborder_supplied
+        is_xborder                = ip_xborders_allborders
+      CHANGING
+        cs_complete_style_border  = complete_style-borders-allborders
+        cs_complete_stylex_border = complete_stylex-borders-allborders ).
+    multiple_change_requested-borders-allborders = abap_true.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_complete_borders_diagonal.
+
+    lv_xborder_supplied = boolc( ip_xborders_diagonal IS SUPPLIED ).
+    move_supplied_borders(
+      EXPORTING
+        iv_border_supplied        = lv_border_supplied
+        is_border                 = ip_borders_diagonal
+        iv_xborder_supplied       = lv_xborder_supplied
+        is_xborder                = ip_xborders_diagonal
+      CHANGING
+        cs_complete_style_border  = complete_style-borders-diagonal
+        cs_complete_stylex_border = complete_stylex-borders-diagonal ).
+    multiple_change_requested-borders-diagonal = abap_true.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_complete_borders_down.
+
+    lv_xborder_supplied = boolc( ip_xborders_down IS SUPPLIED ).
+    move_supplied_borders(
+      EXPORTING
+        iv_border_supplied        = lv_border_supplied
+        is_border                 = ip_borders_down
+        iv_xborder_supplied       = lv_xborder_supplied
+        is_xborder                = ip_xborders_down
+      CHANGING
+        cs_complete_style_border  = complete_style-borders-down
+        cs_complete_stylex_border = complete_stylex-borders-down ).
+    multiple_change_requested-borders-down = abap_true.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_complete_borders_left.
+
+    lv_xborder_supplied = boolc( ip_xborders_left IS SUPPLIED ).
+    move_supplied_borders(
+      EXPORTING
+        iv_border_supplied        = lv_border_supplied
+        is_border                 = ip_borders_left
+        iv_xborder_supplied       = lv_xborder_supplied
+        is_xborder                = ip_xborders_left
+      CHANGING
+        cs_complete_style_border  = complete_style-borders-left
+        cs_complete_stylex_border = complete_stylex-borders-left ).
+    multiple_change_requested-borders-left = abap_true.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_complete_borders_right.
+
+    lv_xborder_supplied = boolc( ip_xborders_right IS SUPPLIED ).
+    move_supplied_borders(
+      EXPORTING
+        iv_border_supplied        = lv_border_supplied
+        is_border                 = ip_borders_right
+        iv_xborder_supplied       = lv_xborder_supplied
+        is_xborder                = ip_xborders_right
+      CHANGING
+        cs_complete_style_border  = complete_style-borders-right
+        cs_complete_stylex_border = complete_stylex-borders-right ).
+    multiple_change_requested-borders-right = abap_true.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_complete_borders_top.
+
+    lv_xborder_supplied = boolc( ip_xborders_top IS SUPPLIED ).
+    move_supplied_borders(
+      EXPORTING
+        iv_border_supplied        = lv_border_supplied
+        is_border                 = ip_borders_top
+        iv_xborder_supplied       = lv_xborder_supplied
+        is_xborder                = ip_xborders_top
+      CHANGING
+        cs_complete_style_border  = complete_style-borders-top
+        cs_complete_stylex_border = complete_stylex-borders-top ).
+    multiple_change_requested-borders-top = abap_true.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_bold.
+
+    complete_style-font-bold = value.
+    complete_stylex-font-bold = 'X'.
+    single_change_requested-font-bold = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_color.
+
+    complete_style-font-color = value.
+    complete_stylex-font-color-rgb = 'X'.
+    single_change_requested-font-color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_color_rgb.
+
+    complete_style-font-color-rgb = value.
+    complete_stylex-font-color-rgb = 'X'.
+    single_change_requested-font-color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_color_indexed.
+
+    complete_style-font-color-indexed = value.
+    complete_stylex-font-color-indexed = 'X'.
+    single_change_requested-font-color-indexed = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_color_theme.
+
+    complete_style-font-color-theme = value.
+    complete_stylex-font-color-theme = 'X'.
+    single_change_requested-font-color-theme = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_color_tint.
+
+    complete_style-font-color-tint = value.
+    complete_stylex-font-color-tint = 'X'.
+    single_change_requested-font-color-tint = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_family.
+
+    complete_style-font-family = value.
+    complete_stylex-font-family = 'X'.
+    single_change_requested-font-family = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_italic.
+
+    complete_style-font-italic = value.
+    complete_stylex-font-italic = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_name.
+
+    complete_style-font-name = value.
+    complete_stylex-font-name = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_scheme.
+
+    complete_style-font-scheme = value.
+    complete_stylex-font-scheme = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_strikethrough.
+
+    complete_style-font-strikethrough = value.
+    complete_stylex-font-strikethrough = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_underline.
+
+    complete_style-font-underline = value.
+    complete_stylex-font-underline = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_font_underline_mode.
+
+    complete_style-font-underline_mode = value.
+    complete_stylex-font-underline_mode = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_filltype.
+
+    complete_style-fill-filltype = value.
+    complete_stylex-fill-filltype = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_rotation.
+
+    complete_style-fill-rotation = value.
+    complete_stylex-fill-rotation = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_fgcolor.
+
+    complete_style-fill-fgcolor = value.
+    complete_stylex-fill-fgcolor-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_fgcolor_rgb.
+
+    complete_style-fill-fgcolor-rgb = value.
+    complete_stylex-fill-fgcolor-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_fgcolor_indexed.
+
+    complete_style-fill-fgcolor-indexed = value.
+    complete_stylex-fill-fgcolor-indexed = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_fgcolor_theme.
+
+    complete_style-fill-fgcolor-theme = value.
+    complete_stylex-fill-fgcolor-theme = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_fgcolor_tint.
+
+    complete_style-fill-fgcolor-tint = value.
+    complete_stylex-fill-fgcolor-tint = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_bgcolor.
+
+    complete_style-fill-bgcolor = value.
+    complete_stylex-fill-bgcolor-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_bgcolor_rgb.
+
+    complete_style-fill-bgcolor-rgb = value.
+    complete_stylex-fill-bgcolor-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_bgcolor_indexed.
+
+    complete_style-fill-bgcolor-indexed = value.
+    complete_stylex-fill-bgcolor-indexed = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_bgcolor_theme.
+
+    complete_style-fill-bgcolor-theme = value.
+    complete_stylex-fill-bgcolor-theme = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_bgcolor_tint.
+
+    complete_style-fill-bgcolor-tint = value.
+    complete_stylex-fill-bgcolor-tint = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_gradtype_type.
+
+    complete_style-fill-gradtype-type = value.
+    complete_stylex-fill-gradtype-type = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_gradtype_degree.
+
+    complete_style-fill-gradtype-degree = value.
+    complete_stylex-fill-gradtype-degree = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_gradtype_bottom.
+
+    complete_style-fill-gradtype-bottom = value.
+    complete_stylex-fill-gradtype-bottom = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_gradtype_left.
+
+    complete_style-fill-gradtype-left = value.
+    complete_stylex-fill-gradtype-left = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_gradtype_top.
+
+    complete_style-fill-gradtype-top = value.
+    complete_stylex-fill-gradtype-top = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_gradtype_right.
+
+    complete_style-fill-gradtype-right = value.
+    complete_stylex-fill-gradtype-right = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_gradtype_position1.
+
+    complete_style-fill-gradtype-position1 = value.
+    complete_stylex-fill-gradtype-position1 = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_gradtype_position2.
+
+    complete_style-fill-gradtype-position2 = value.
+    complete_stylex-fill-gradtype-position2 = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_fill_gradtype_position3.
+
+    complete_style-fill-gradtype-position3 = value.
+    complete_stylex-fill-gradtype-position3 = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_diagonal_mode.
+
+    complete_style-borders-diagonal_mode = value.
+    complete_stylex-borders-diagonal_mode = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_alignment_horizontal.
+
+    complete_style-alignment-horizontal = value.
+    complete_stylex-alignment-horizontal = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_alignment_vertical.
+
+    complete_style-alignment-vertical = value.
+    complete_stylex-alignment-vertical = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_alignment_textrotation.
+
+    complete_style-alignment-textrotation = value.
+    complete_stylex-alignment-textrotation = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_alignment_wraptext.
+
+    complete_style-alignment-wraptext = value.
+    complete_stylex-alignment-wraptext = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_alignment_shrinktofit.
+
+    complete_style-alignment-shrinktofit = value.
+    complete_stylex-alignment-shrinktofit = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_alignment_indent.
+
+    complete_style-alignment-indent = value.
+    complete_stylex-alignment-indent = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_protection_hidden.
+
+    complete_style-protection-hidden = value.
+    complete_stylex-protection-hidden = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_protection_locked.
+
+    complete_style-protection-locked = value.
+    complete_stylex-protection-locked = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_allborders_style.
+
+    complete_style-borders-allborders-border_style = value.
+    complete_stylex-borders-allborders-border_style = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_allborders_color.
+
+    complete_style-borders-allborders-border_color = value.
+    complete_stylex-borders-allborders-border_color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_allbo_color_rgb.
+
+    complete_style-borders-allborders-border_color-rgb = value.
+    complete_stylex-borders-allborders-border_color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_allbo_color_indexe.
+
+    complete_style-borders-allborders-border_color-indexed = value.
+    complete_stylex-borders-allborders-border_color-indexed = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_allbo_color_theme.
+
+    complete_style-borders-allborders-border_color-theme = value.
+    complete_stylex-borders-allborders-border_color-theme = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_allbo_color_tint.
+
+    complete_style-borders-allborders-border_color-tint = value.
+    complete_stylex-borders-allborders-border_color-tint = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_diagonal_style.
+
+    complete_style-borders-diagonal-border_style = value.
+    complete_stylex-borders-diagonal-border_style = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_diagonal_color.
+
+    complete_style-borders-diagonal-border_color = value.
+    complete_stylex-borders-diagonal-border_color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_diagonal_color_rgb.
+
+    complete_style-borders-diagonal-border_color-rgb = value.
+    complete_stylex-borders-diagonal-border_color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_diagonal_color_ind.
+
+    complete_style-borders-diagonal-border_color-indexed = value.
+    complete_stylex-borders-diagonal-border_color-indexed = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_diagonal_color_the.
+
+    complete_style-borders-diagonal-border_color-theme = value.
+    complete_stylex-borders-diagonal-border_color-theme = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_diagonal_color_tin.
+
+    complete_style-borders-diagonal-border_color-tint = value.
+    complete_stylex-borders-diagonal-border_color-tint = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_down_style.
+
+    complete_style-borders-down-border_style = value.
+    complete_stylex-borders-down-border_style = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_down_color.
+
+    complete_style-borders-down-border_color = value.
+    complete_stylex-borders-down-border_color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_down_color_rgb.
+
+    complete_style-borders-down-border_color-rgb = value.
+    complete_stylex-borders-down-border_color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_down_color_indexed.
+
+    complete_style-borders-down-border_color-indexed = value.
+    complete_stylex-borders-down-border_color-indexed = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_down_color_theme.
+
+    complete_style-borders-down-border_color-theme = value.
+    complete_stylex-borders-down-border_color-theme = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_down_color_tint.
+
+    complete_style-borders-down-border_color-tint = value.
+    complete_stylex-borders-down-border_color-tint = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_left_style.
+
+    complete_style-borders-left-border_style = value.
+    complete_stylex-borders-left-border_style = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_left_color.
+
+    complete_style-borders-left-border_color = value.
+    complete_stylex-borders-left-border_color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_left_color_rgb.
+
+    complete_style-borders-left-border_color-rgb = value.
+    complete_stylex-borders-left-border_color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_left_color_indexed.
+
+    complete_style-borders-left-border_color-indexed = value.
+    complete_stylex-borders-left-border_color-indexed = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_left_color_theme.
+
+    complete_style-borders-left-border_color-theme = value.
+    complete_stylex-borders-left-border_color-theme = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_left_color_tint.
+
+    complete_style-borders-left-border_color-tint = value.
+    complete_stylex-borders-left-border_color-tint = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_right_style.
+
+    complete_style-borders-right-border_style = value.
+    complete_stylex-borders-right-border_style = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_right_color.
+
+    complete_style-borders-right-border_color = value.
+    complete_stylex-borders-right-border_color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_right_color_rgb.
+
+    complete_style-borders-right-border_color-rgb = value.
+    complete_stylex-borders-right-border_color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_right_color_indexe.
+
+    complete_style-borders-right-border_color-indexed = value.
+    complete_stylex-borders-right-border_color-indexed = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_right_color_theme.
+
+    complete_style-borders-right-border_color-theme = value.
+    complete_stylex-borders-right-border_color-theme = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_right_color_tint.
+
+    complete_style-borders-right-border_color-tint = value.
+    complete_stylex-borders-right-border_color-tint = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_top_style.
+
+    complete_style-borders-top-border_style = value.
+    complete_stylex-borders-top-border_style = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_top_color.
+
+    complete_style-borders-top-border_color = value.
+    complete_stylex-borders-top-border_color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_top_color_rgb.
+
+    complete_style-borders-top-border_color-rgb = value.
+    complete_stylex-borders-top-border_color-rgb = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_top_color_indexed.
+
+    complete_style-borders-top-border_color-indexed = value.
+    complete_stylex-borders-top-border_color-indexed = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_top_color_theme.
+
+    complete_style-borders-top-border_color-theme = value.
+    complete_stylex-borders-top-border_color-theme = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+  METHOD zif_excel_style_changer~set_borders_top_color_tint.
+
+    complete_style-borders-top-border_color-tint = value.
+    complete_stylex-borders-top-border_color-tint = 'X'.
+
+    result = me.
+
+  ENDMETHOD.
+
+
+ENDCLASS.

--- a/src/zcl_excel_style_changer.clas.abap
+++ b/src/zcl_excel_style_changer.clas.abap
@@ -15,23 +15,6 @@ CLASS zcl_excel_style_changer DEFINITION
       RAISING
         zcx_excel.
 
-*    CLASS-METHODS get
-*      IMPORTING
-*        excel         TYPE REF TO zcl_excel
-*      RETURNING
-*        VALUE(result) TYPE REF TO zif_excel_style_changer
-*      RAISING
-*        zcx_excel.
-*
-*    CLASS-METHODS get_from_guid
-*      IMPORTING
-*        excel         TYPE REF TO zcl_excel
-*        guid          TYPE zexcel_cell_style
-*      RETURNING
-*        VALUE(result) TYPE REF TO zif_excel_style_changer
-*      RAISING
-*        zcx_excel.
-
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -108,32 +91,6 @@ CLASS zcl_excel_style_changer IMPLEMENTATION.
     CREATE OBJECT style.
     style->excel = excel.
     result = style.
-
-*  ENDMETHOD.
-*
-*
-*  METHOD get.
-*
-*    DATA: style TYPE REF TO zcl_excel_style_changer.
-*
-*    CREATE OBJECT style.
-*    style->excel = excel.
-*    result = style.
-*
-*  ENDMETHOD.
-*
-*
-*  METHOD get_from_guid.
-*
-*    DATA: style TYPE REF TO zcl_excel_style_changer.
-*
-*    DATA(stylemapping) = excel->get_style_to_guid( guid ).
-*    CREATE OBJECT style.
-*    style->excel = excel.
-*    style->complete_style = stylemapping-complete_style.
-*    style->complete_stylex = stylemapping-complete_stylex.
-*
-*    result = style.
 
   ENDMETHOD.
 
@@ -562,11 +519,11 @@ CLASS zcl_excel_style_changer IMPLEMENTATION.
 * Now we have a completly filled styles.
 * This can be used to get the guid
 * Return guid if requested.  Might be used if copy&paste of styles is requested
-    l_guid = me->excel->get_static_cellstyle_guid( ip_cstyle_complete  = stylemapping-complete_style
+    ep_guid = me->excel->get_static_cellstyle_guid( ip_cstyle_complete  = stylemapping-complete_style
                                                    ip_cstylex_complete = stylemapping-complete_stylex  ).
     lo_worksheet->set_cell_style( ip_column = ip_column
                                   ip_row    = ip_row
-                                  ip_style  = l_guid ).
+                                  ip_style  = ep_guid ).
 
   ENDMETHOD.
 

--- a/src/zcl_excel_style_changer.clas.xml
+++ b/src/zcl_excel_style_changer.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_EXCEL_STYLE_CHANGER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Style changer</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -1751,9 +1751,9 @@ CLASS zcl_excel_worksheet IMPLEMENTATION.
     ENDIF.
 
 
-    changer->apply( ip_worksheet = me
-                    ip_column    = ip_column
-                    ip_row       = ip_row ).
+    ep_guid = changer->apply( ip_worksheet = me
+                              ip_column    = ip_column
+                              ip_row       = ip_row ).
 
 
   ENDMETHOD.                    "CHANGE_CELL_STYLE

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -1387,619 +1387,374 @@ CLASS zcl_excel_worksheet IMPLEMENTATION.
 
 
   METHOD change_cell_style.
-    " issue # 139
-    DATA: stylemapping    TYPE zexcel_s_stylemapping,
-          complete_style  TYPE zexcel_s_cstyle_complete,
-          complete_stylex TYPE zexcel_s_cstylex_complete,
-          l_guid          TYPE zexcel_cell_style.   "issue # 177
-    DATA: lv_border_supplied  TYPE abap_bool,
-          lv_xborder_supplied TYPE abap_bool,
-          lv_style_supplied   TYPE abap_bool.
 
-* First get current stylsettings
-    TRY.
-        me->get_cell( EXPORTING ip_column = ip_column  " Cell Column
-                                ip_row    = ip_row      " Cell Row
-                      IMPORTING ep_guid   = l_guid )." Cell Value ).  "issue # 177
+    DATA: changer TYPE REF TO zif_excel_style_changer.
 
 
-        stylemapping = me->excel->get_style_to_guid( l_guid ).        "issue # 177
-        complete_style  = stylemapping-complete_style.
-        complete_stylex = stylemapping-complete_stylex.
-      CATCH zcx_excel.
-* Error --> use submitted style
-    ENDTRY.
+    changer = zcl_excel_style_changer=>create( excel = excel ).
 
-*  move_supplied_multistyles: complete.
+
     IF ip_complete IS SUPPLIED.
       IF ip_xcomplete IS NOT SUPPLIED.
         zcx_excel=>raise_text( 'Complete styleinfo has to be supplied with corresponding X-field' ).
       ENDIF.
-      MOVE-CORRESPONDING ip_complete  TO complete_style.
-      MOVE-CORRESPONDING ip_xcomplete TO complete_stylex.
+      changer->set_complete( ip_complete = ip_complete ip_xcomplete = ip_xcomplete ).
     ENDIF.
 
 
 
     IF ip_font IS SUPPLIED.
-      DATA: fontx LIKE ip_xfont.
       IF ip_xfont IS SUPPLIED.
-        fontx = ip_xfont.
+        changer->set_complete_font( ip_font = ip_font ip_xfont = ip_xfont ).
       ELSE.
-* Only supplied values should be used - exception: Flags bold and italic strikethrough underline
-        MOVE 'X' TO: fontx-bold,
-                     fontx-italic,
-                     fontx-strikethrough,
-                     fontx-underline_mode.
-        CLEAR fontx-color WITH 'X'.
-        clear_initial_colorxfields(
-          EXPORTING
-            is_color  = ip_font-color
-          CHANGING
-            cs_xcolor = fontx-color ).
-        IF ip_font-family IS NOT INITIAL.
-          fontx-family = 'X'.
-        ENDIF.
-        IF ip_font-name IS NOT INITIAL.
-          fontx-name = 'X'.
-        ENDIF.
-        IF ip_font-scheme IS NOT INITIAL.
-          fontx-scheme = 'X'.
-        ENDIF.
-        IF ip_font-size IS NOT INITIAL.
-          fontx-size = 'X'.
-        ENDIF.
-        IF ip_font-underline_mode IS NOT INITIAL.
-          fontx-underline_mode = 'X'.
-        ENDIF.
+        changer->set_complete_font( ip_font = ip_font ).
       ENDIF.
-      MOVE-CORRESPONDING ip_font  TO complete_style-font.
-      MOVE-CORRESPONDING fontx    TO complete_stylex-font.
-* Correction for undeline mode
     ENDIF.
 
     IF ip_fill IS SUPPLIED.
-      DATA: fillx LIKE ip_xfill.
       IF ip_xfill IS SUPPLIED.
-        fillx = ip_xfill.
+        changer->set_complete_fill( ip_fill = ip_fill ip_xfill = ip_xfill ).
       ELSE.
-        CLEAR fillx WITH 'X'.
-        IF ip_fill-filltype IS INITIAL.
-          CLEAR fillx-filltype.
-        ENDIF.
-        clear_initial_colorxfields(
-          EXPORTING
-            is_color  = ip_fill-fgcolor
-          CHANGING
-            cs_xcolor = fillx-fgcolor ).
-        clear_initial_colorxfields(
-          EXPORTING
-            is_color  = ip_fill-bgcolor
-          CHANGING
-            cs_xcolor = fillx-bgcolor ).
-
+        changer->set_complete_fill( ip_fill = ip_fill ).
       ENDIF.
-      MOVE-CORRESPONDING ip_fill  TO complete_style-fill.
-      MOVE-CORRESPONDING fillx    TO complete_stylex-fill.
     ENDIF.
 
 
     IF ip_borders IS SUPPLIED.
-      DATA: bordersx LIKE ip_xborders.
       IF ip_xborders IS SUPPLIED.
-        bordersx = ip_xborders.
+        changer->set_complete_borders( ip_borders = ip_borders ip_xborders = ip_xborders ).
       ELSE.
-        CLEAR bordersx WITH 'X'.
-        IF ip_borders-allborders-border_style IS INITIAL.
-          CLEAR bordersx-allborders-border_style.
-        ENDIF.
-        IF ip_borders-diagonal-border_style IS INITIAL.
-          CLEAR bordersx-diagonal-border_style.
-        ENDIF.
-        IF ip_borders-down-border_style IS INITIAL.
-          CLEAR bordersx-down-border_style.
-        ENDIF.
-        IF ip_borders-left-border_style IS INITIAL.
-          CLEAR bordersx-left-border_style.
-        ENDIF.
-        IF ip_borders-right-border_style IS INITIAL.
-          CLEAR bordersx-right-border_style.
-        ENDIF.
-        IF ip_borders-top-border_style IS INITIAL.
-          CLEAR bordersx-top-border_style.
-        ENDIF.
-
-        clear_initial_colorxfields(
-          EXPORTING
-            is_color  = ip_borders-allborders-border_color
-          CHANGING
-            cs_xcolor = bordersx-allborders-border_color ).
-
-        clear_initial_colorxfields(
-          EXPORTING
-            is_color  = ip_borders-diagonal-border_color
-          CHANGING
-            cs_xcolor = bordersx-diagonal-border_color ).
-
-        clear_initial_colorxfields(
-          EXPORTING
-            is_color  = ip_borders-down-border_color
-          CHANGING
-            cs_xcolor = bordersx-down-border_color ).
-
-        clear_initial_colorxfields(
-          EXPORTING
-            is_color  = ip_borders-left-border_color
-          CHANGING
-            cs_xcolor = bordersx-left-border_color ).
-
-        clear_initial_colorxfields(
-          EXPORTING
-            is_color  = ip_borders-right-border_color
-          CHANGING
-            cs_xcolor = bordersx-right-border_color ).
-
-        clear_initial_colorxfields(
-          EXPORTING
-            is_color  = ip_borders-top-border_color
-          CHANGING
-            cs_xcolor = bordersx-top-border_color ).
-
+        changer->set_complete_borders( ip_borders = ip_borders ).
       ENDIF.
-      MOVE-CORRESPONDING ip_borders  TO complete_style-borders.
-      MOVE-CORRESPONDING bordersx    TO complete_stylex-borders.
     ENDIF.
 
     IF ip_alignment IS SUPPLIED.
-      DATA: alignmentx LIKE ip_xalignment.
       IF ip_xalignment IS SUPPLIED.
-        alignmentx = ip_xalignment.
+        changer->set_complete_alignment( ip_alignment = ip_alignment ip_xalignment = ip_xalignment ).
       ELSE.
-        CLEAR alignmentx WITH 'X'.
-        IF ip_alignment-horizontal IS INITIAL.
-          CLEAR alignmentx-horizontal.
-        ENDIF.
-        IF ip_alignment-vertical IS INITIAL.
-          CLEAR alignmentx-vertical.
-        ENDIF.
+        changer->set_complete_alignment( ip_alignment = ip_alignment ).
       ENDIF.
-      MOVE-CORRESPONDING ip_alignment  TO complete_style-alignment.
-      MOVE-CORRESPONDING alignmentx    TO complete_stylex-alignment.
     ENDIF.
 
     IF ip_protection IS SUPPLIED.
-      MOVE-CORRESPONDING ip_protection  TO complete_style-protection.
       IF ip_xprotection IS SUPPLIED.
-        MOVE-CORRESPONDING ip_xprotection TO complete_stylex-protection.
+        changer->set_complete_protection( ip_protection = ip_protection ip_xprotection = ip_xprotection ).
       ELSE.
-        IF ip_protection-hidden IS NOT INITIAL.
-          complete_stylex-protection-hidden = 'X'.
-        ENDIF.
-        IF ip_protection-locked IS NOT INITIAL.
-          complete_stylex-protection-locked = 'X'.
-        ENDIF.
+        changer->set_complete_protection( ip_protection = ip_protection ).
       ENDIF.
     ENDIF.
 
 
-    lv_border_supplied = boolc( ip_borders_allborders IS SUPPLIED ).
-    lv_xborder_supplied = boolc( ip_xborders_allborders IS SUPPLIED ).
-    move_supplied_borders(
-      EXPORTING
-        iv_border_supplied        = lv_border_supplied
-        is_border                 = ip_borders_allborders
-        iv_xborder_supplied       = lv_xborder_supplied
-        is_xborder                = ip_xborders_allborders
-      CHANGING
-        cs_complete_style_border  = complete_style-borders-allborders
-        cs_complete_stylex_border = complete_stylex-borders-allborders ).
+    IF ip_borders_allborders IS SUPPLIED.
+      IF ip_xborders_allborders IS SUPPLIED.
+        changer->set_complete_borders_all( ip_borders_allborders = ip_borders_allborders ip_xborders_allborders = ip_xborders_allborders ).
+      ELSE.
+        changer->set_complete_borders_all( ip_borders_allborders = ip_borders_allborders ).
+      ENDIF.
+    ENDIF.
 
-    lv_border_supplied = boolc( ip_borders_diagonal IS SUPPLIED ).
-    lv_xborder_supplied = boolc( ip_xborders_diagonal IS SUPPLIED ).
-    move_supplied_borders(
-      EXPORTING
-        iv_border_supplied        = lv_border_supplied
-        is_border                 = ip_borders_diagonal
-        iv_xborder_supplied       = lv_xborder_supplied
-        is_xborder                = ip_xborders_diagonal
-      CHANGING
-        cs_complete_style_border  = complete_style-borders-diagonal
-        cs_complete_stylex_border = complete_stylex-borders-diagonal ).
+    IF ip_borders_diagonal IS SUPPLIED.
+      IF ip_xborders_diagonal IS SUPPLIED.
+        changer->set_complete_borders_diagonal( ip_borders_diagonal = ip_borders_diagonal ip_xborders_diagonal = ip_xborders_diagonal ).
+      ELSE.
+        changer->set_complete_borders_diagonal( ip_borders_diagonal = ip_borders_diagonal ).
+      ENDIF.
+    ENDIF.
 
-    lv_border_supplied = boolc( ip_borders_down IS SUPPLIED ).
-    lv_xborder_supplied = boolc( ip_xborders_down IS SUPPLIED ).
-    move_supplied_borders(
-      EXPORTING
-        iv_border_supplied        = lv_border_supplied
-        is_border                 = ip_borders_down
-        iv_xborder_supplied       = lv_xborder_supplied
-        is_xborder                = ip_xborders_down
-      CHANGING
-        cs_complete_style_border  = complete_style-borders-down
-        cs_complete_stylex_border = complete_stylex-borders-down ).
+    IF ip_borders_down IS SUPPLIED.
+      IF ip_xborders_down IS SUPPLIED.
+        changer->set_complete_borders_down( ip_borders_down = ip_borders_down ip_xborders_down = ip_xborders_down ).
+      ELSE.
+        changer->set_complete_borders_down( ip_borders_down = ip_borders_down ).
+      ENDIF.
+    ENDIF.
 
-    lv_border_supplied = boolc( ip_borders_left IS SUPPLIED ).
-    lv_xborder_supplied = boolc( ip_xborders_left IS SUPPLIED ).
-    move_supplied_borders(
-      EXPORTING
-        iv_border_supplied        = lv_border_supplied
-        is_border                 = ip_borders_left
-        iv_xborder_supplied       = lv_xborder_supplied
-        is_xborder                = ip_xborders_left
-      CHANGING
-        cs_complete_style_border  = complete_style-borders-left
-        cs_complete_stylex_border = complete_stylex-borders-left ).
+    IF ip_borders_left IS SUPPLIED.
+      IF ip_xborders_left IS SUPPLIED.
+        changer->set_complete_borders_left( ip_borders_left = ip_borders_left ip_xborders_left = ip_xborders_left ).
+      ELSE.
+        changer->set_complete_borders_left( ip_borders_left = ip_borders_left ).
+      ENDIF.
+    ENDIF.
 
-    lv_border_supplied = boolc( ip_borders_right IS SUPPLIED ).
-    lv_xborder_supplied = boolc( ip_xborders_right IS SUPPLIED ).
-    move_supplied_borders(
-      EXPORTING
-        iv_border_supplied        = lv_border_supplied
-        is_border                 = ip_borders_right
-        iv_xborder_supplied       = lv_xborder_supplied
-        is_xborder                = ip_xborders_right
-      CHANGING
-        cs_complete_style_border  = complete_style-borders-right
-        cs_complete_stylex_border = complete_stylex-borders-right ).
+    IF ip_borders_right IS SUPPLIED.
+      IF ip_xborders_right IS SUPPLIED.
+        changer->set_complete_borders_right( ip_borders_right = ip_borders_right ip_xborders_right = ip_xborders_right ).
+      ELSE.
+        changer->set_complete_borders_right( ip_borders_right = ip_borders_right ).
+      ENDIF.
+    ENDIF.
 
-    lv_border_supplied = boolc( ip_borders_top IS SUPPLIED ).
-    lv_xborder_supplied = boolc( ip_xborders_top IS SUPPLIED ).
-    move_supplied_borders(
-      EXPORTING
-        iv_border_supplied        = lv_border_supplied
-        is_border                 = ip_borders_top
-        iv_xborder_supplied       = lv_xborder_supplied
-        is_xborder                = ip_xborders_top
-      CHANGING
-        cs_complete_style_border  = complete_style-borders-top
-        cs_complete_stylex_border = complete_stylex-borders-top ).
+    IF ip_borders_top IS SUPPLIED.
+      IF ip_xborders_top IS SUPPLIED.
+        changer->set_complete_borders_top( ip_borders_top = ip_borders_top ip_xborders_top = ip_xborders_top ).
+      ELSE.
+        changer->set_complete_borders_top( ip_borders_top = ip_borders_top ).
+      ENDIF.
+    ENDIF.
 
     IF ip_number_format_format_code IS SUPPLIED.
-      complete_style-number_format-format_code = ip_number_format_format_code.
-      complete_stylex-number_format-format_code = 'X'.
+      changer->set_number_format( ip_number_format_format_code ).
     ENDIF.
     IF ip_font_bold IS SUPPLIED.
-      complete_style-font-bold = ip_font_bold.
-      complete_stylex-font-bold = 'X'.
+      changer->set_font_bold( ip_font_bold ).
     ENDIF.
     IF ip_font_color IS SUPPLIED.
-      complete_style-font-color = ip_font_color.
-      complete_stylex-font-color-rgb = 'X'.
+      changer->set_font_color( ip_font_color ).
     ENDIF.
     IF ip_font_color_rgb IS SUPPLIED.
-      complete_style-font-color-rgb = ip_font_color_rgb.
-      complete_stylex-font-color-rgb = 'X'.
+      changer->set_font_color_rgb( ip_font_color_rgb ).
     ENDIF.
     IF ip_font_color_indexed IS SUPPLIED.
-      complete_style-font-color-indexed = ip_font_color_indexed.
-      complete_stylex-font-color-indexed = 'X'.
+      changer->set_font_color_indexed( ip_font_color_indexed ).
     ENDIF.
     IF ip_font_color_theme IS SUPPLIED.
-      complete_style-font-color-theme = ip_font_color_theme.
-      complete_stylex-font-color-theme = 'X'.
+      changer->set_font_color_theme( ip_font_color_theme ).
     ENDIF.
     IF ip_font_color_tint IS SUPPLIED.
-      complete_style-font-color-tint = ip_font_color_tint.
-      complete_stylex-font-color-tint = 'X'.
+      changer->set_font_color_tint( ip_font_color_tint ).
     ENDIF.
 
     IF ip_font_family IS SUPPLIED.
-      complete_style-font-family = ip_font_family.
-      complete_stylex-font-family = 'X'.
+      changer->set_font_family( ip_font_family ).
     ENDIF.
     IF ip_font_italic IS SUPPLIED.
-      complete_style-font-italic = ip_font_italic.
-      complete_stylex-font-italic = 'X'.
+      changer->set_font_italic( ip_font_italic ).
     ENDIF.
     IF ip_font_name IS SUPPLIED.
-      complete_style-font-name = ip_font_name.
-      complete_stylex-font-name = 'X'.
+      changer->set_font_name( ip_font_name ).
     ENDIF.
     IF ip_font_scheme IS SUPPLIED.
-      complete_style-font-scheme = ip_font_scheme.
-      complete_stylex-font-scheme = 'X'.
+      changer->set_font_scheme( ip_font_scheme ).
     ENDIF.
     IF ip_font_size IS SUPPLIED.
-      complete_style-font-size = ip_font_size.
-      complete_stylex-font-size = 'X'.
+      changer->set_font_size( ip_font_size ).
     ENDIF.
     IF ip_font_strikethrough IS SUPPLIED.
-      complete_style-font-strikethrough = ip_font_strikethrough.
-      complete_stylex-font-strikethrough = 'X'.
+      changer->set_font_strikethrough( ip_font_strikethrough ).
     ENDIF.
     IF ip_font_underline IS SUPPLIED.
-      complete_style-font-underline = ip_font_underline.
-      complete_stylex-font-underline = 'X'.
+      changer->set_font_underline( ip_font_underline ).
     ENDIF.
     IF ip_font_underline_mode IS SUPPLIED.
-      complete_style-font-underline_mode = ip_font_underline_mode.
-      complete_stylex-font-underline_mode = 'X'.
+      changer->set_font_underline_mode( ip_font_underline_mode ).
     ENDIF.
+
     IF ip_fill_filltype IS SUPPLIED.
-      complete_style-fill-filltype = ip_fill_filltype.
-      complete_stylex-fill-filltype = 'X'.
+      changer->set_fill_filltype( ip_fill_filltype ).
     ENDIF.
     IF ip_fill_rotation IS SUPPLIED.
-      complete_style-fill-rotation = ip_fill_rotation.
-      complete_stylex-fill-rotation = 'X'.
+      changer->set_fill_rotation( ip_fill_rotation ).
     ENDIF.
     IF ip_fill_fgcolor IS SUPPLIED.
-      complete_style-fill-fgcolor = ip_fill_fgcolor.
-      complete_stylex-fill-fgcolor-rgb = 'X'.
+      changer->set_fill_fgcolor( ip_fill_fgcolor ).
     ENDIF.
     IF ip_fill_fgcolor_rgb IS SUPPLIED.
-      complete_style-fill-fgcolor-rgb = ip_fill_fgcolor_rgb.
-      complete_stylex-fill-fgcolor-rgb = 'X'.
+      changer->set_fill_fgcolor_rgb( ip_fill_fgcolor_rgb ).
     ENDIF.
     IF ip_fill_fgcolor_indexed IS SUPPLIED.
-      complete_style-fill-fgcolor-indexed = ip_fill_fgcolor_indexed.
-      complete_stylex-fill-fgcolor-indexed = 'X'.
+      changer->set_fill_fgcolor_indexed( ip_fill_fgcolor_indexed ).
     ENDIF.
     IF ip_fill_fgcolor_theme IS SUPPLIED.
-      complete_style-fill-fgcolor-theme = ip_fill_fgcolor_theme.
-      complete_stylex-fill-fgcolor-theme = 'X'.
+      changer->set_fill_fgcolor_theme( ip_fill_fgcolor_theme ).
     ENDIF.
     IF ip_fill_fgcolor_tint IS SUPPLIED.
-      complete_style-fill-fgcolor-tint = ip_fill_fgcolor_tint.
-      complete_stylex-fill-fgcolor-tint = 'X'.
+      changer->set_fill_fgcolor_tint( ip_fill_fgcolor_tint ).
     ENDIF.
 
     IF ip_fill_bgcolor IS SUPPLIED.
-      complete_style-fill-bgcolor = ip_fill_bgcolor.
-      complete_stylex-fill-bgcolor-rgb = 'X'.
+      changer->set_fill_bgcolor( ip_fill_bgcolor ).
     ENDIF.
     IF ip_fill_bgcolor_rgb IS SUPPLIED.
-      complete_style-fill-bgcolor-rgb = ip_fill_bgcolor_rgb.
-      complete_stylex-fill-bgcolor-rgb = 'X'.
+      changer->set_fill_bgcolor_rgb( ip_fill_bgcolor_rgb ).
     ENDIF.
     IF ip_fill_bgcolor_indexed IS SUPPLIED.
-      complete_style-fill-bgcolor-indexed = ip_fill_bgcolor_indexed.
-      complete_stylex-fill-bgcolor-indexed = 'X'.
+      changer->set_fill_bgcolor_indexed( ip_fill_bgcolor_indexed ).
     ENDIF.
     IF ip_fill_bgcolor_theme IS SUPPLIED.
-      complete_style-fill-bgcolor-theme = ip_fill_bgcolor_theme.
-      complete_stylex-fill-bgcolor-theme = 'X'.
+      changer->set_fill_bgcolor_theme( ip_fill_bgcolor_theme ).
     ENDIF.
     IF ip_fill_bgcolor_tint IS SUPPLIED.
-      complete_style-fill-bgcolor-tint = ip_fill_bgcolor_tint.
-      complete_stylex-fill-bgcolor-tint = 'X'.
+      changer->set_fill_bgcolor_tint( ip_fill_bgcolor_tint ).
     ENDIF.
 
     IF ip_fill_gradtype_type IS SUPPLIED.
-      complete_style-fill-gradtype-type = ip_fill_gradtype_type.
-      complete_stylex-fill-gradtype-type = 'X'.
+      changer->set_fill_gradtype_type( ip_fill_gradtype_type ).
     ENDIF.
     IF ip_fill_gradtype_degree IS SUPPLIED.
-      complete_style-fill-gradtype-degree = ip_fill_gradtype_degree.
-      complete_stylex-fill-gradtype-degree = 'X'.
+      changer->set_fill_gradtype_degree( ip_fill_gradtype_degree ).
     ENDIF.
     IF ip_fill_gradtype_bottom IS SUPPLIED.
-      complete_style-fill-gradtype-bottom = ip_fill_gradtype_bottom.
-      complete_stylex-fill-gradtype-bottom = 'X'.
+      changer->set_fill_gradtype_bottom( ip_fill_gradtype_bottom ).
     ENDIF.
     IF ip_fill_gradtype_left IS SUPPLIED.
-      complete_style-fill-gradtype-left = ip_fill_gradtype_left.
-      complete_stylex-fill-gradtype-left = 'X'.
+      changer->set_fill_gradtype_left( ip_fill_gradtype_left ).
     ENDIF.
     IF ip_fill_gradtype_top IS SUPPLIED.
-      complete_style-fill-gradtype-top = ip_fill_gradtype_top.
-      complete_stylex-fill-gradtype-top = 'X'.
+      changer->set_fill_gradtype_top( ip_fill_gradtype_top ).
     ENDIF.
     IF ip_fill_gradtype_right IS SUPPLIED.
-      complete_style-fill-gradtype-right = ip_fill_gradtype_right.
-      complete_stylex-fill-gradtype-right = 'X'.
+      changer->set_fill_gradtype_right( ip_fill_gradtype_right ).
     ENDIF.
     IF ip_fill_gradtype_position1 IS SUPPLIED.
-      complete_style-fill-gradtype-position1 = ip_fill_gradtype_position1.
-      complete_stylex-fill-gradtype-position1 = 'X'.
+      changer->set_fill_gradtype_position1( ip_fill_gradtype_position1 ).
     ENDIF.
     IF ip_fill_gradtype_position2 IS SUPPLIED.
-      complete_style-fill-gradtype-position2 = ip_fill_gradtype_position2.
-      complete_stylex-fill-gradtype-position2 = 'X'.
+      changer->set_fill_gradtype_position2( ip_fill_gradtype_position2 ).
     ENDIF.
     IF ip_fill_gradtype_position3 IS SUPPLIED.
-      complete_style-fill-gradtype-position3 = ip_fill_gradtype_position3.
-      complete_stylex-fill-gradtype-position3 = 'X'.
+      changer->set_fill_gradtype_position3( ip_fill_gradtype_position3 ).
     ENDIF.
 
 
 
     IF ip_borders_diagonal_mode IS SUPPLIED.
-      complete_style-borders-diagonal_mode = ip_borders_diagonal_mode.
-      complete_stylex-borders-diagonal_mode = 'X'.
+      changer->set_borders_diagonal_mode( ip_borders_diagonal_mode ).
     ENDIF.
     IF ip_alignment_horizontal IS SUPPLIED.
-      complete_style-alignment-horizontal = ip_alignment_horizontal.
-      complete_stylex-alignment-horizontal = 'X'.
+      changer->set_alignment_horizontal( ip_alignment_horizontal ).
     ENDIF.
     IF ip_alignment_vertical IS SUPPLIED.
-      complete_style-alignment-vertical = ip_alignment_vertical.
-      complete_stylex-alignment-vertical = 'X'.
+      changer->set_alignment_vertical( ip_alignment_vertical ).
     ENDIF.
     IF ip_alignment_textrotation IS SUPPLIED.
-      complete_style-alignment-textrotation = ip_alignment_textrotation.
-      complete_stylex-alignment-textrotation = 'X'.
+      changer->set_alignment_textrotation( ip_alignment_textrotation ).
     ENDIF.
     IF ip_alignment_wraptext IS SUPPLIED.
-      complete_style-alignment-wraptext = ip_alignment_wraptext.
-      complete_stylex-alignment-wraptext = 'X'.
+      changer->set_alignment_wraptext( ip_alignment_wraptext ).
     ENDIF.
     IF ip_alignment_shrinktofit IS SUPPLIED.
-      complete_style-alignment-shrinktofit = ip_alignment_shrinktofit.
-      complete_stylex-alignment-shrinktofit = 'X'.
+      changer->set_alignment_shrinktofit( ip_alignment_shrinktofit ).
     ENDIF.
     IF ip_alignment_indent IS SUPPLIED.
-      complete_style-alignment-indent = ip_alignment_indent.
-      complete_stylex-alignment-indent = 'X'.
+      changer->set_alignment_indent( ip_alignment_indent ).
     ENDIF.
     IF ip_protection_hidden IS SUPPLIED.
-      complete_style-protection-hidden = ip_protection_hidden.
-      complete_stylex-protection-hidden = 'X'.
+      changer->set_protection_hidden( ip_protection_hidden ).
     ENDIF.
     IF ip_protection_locked IS SUPPLIED.
-      complete_style-protection-locked = ip_protection_locked.
-      complete_stylex-protection-locked = 'X'.
+      changer->set_protection_locked( ip_protection_locked ).
     ENDIF.
 
     IF ip_borders_allborders_style IS SUPPLIED.
-      complete_style-borders-allborders-border_style = ip_borders_allborders_style.
-      complete_stylex-borders-allborders-border_style = 'X'.
+      changer->set_borders_allborders_style( ip_borders_allborders_style ).
     ENDIF.
     IF ip_borders_allborders_color IS SUPPLIED.
-      complete_style-borders-allborders-border_color = ip_borders_allborders_color.
-      complete_stylex-borders-allborders-border_color-rgb = 'X'.
+      changer->set_borders_allborders_color( ip_borders_allborders_color ).
     ENDIF.
     IF ip_borders_allbo_color_rgb IS SUPPLIED.
-      complete_style-borders-allborders-border_color-rgb = ip_borders_allbo_color_rgb.
-      complete_stylex-borders-allborders-border_color-rgb = 'X'.
+      changer->set_borders_allbo_color_rgb( ip_borders_allbo_color_rgb ).
     ENDIF.
     IF ip_borders_allbo_color_indexed IS SUPPLIED.
-      complete_style-borders-allborders-border_color-indexed = ip_borders_allbo_color_indexed.
-      complete_stylex-borders-allborders-border_color-indexed = 'X'.
+      changer->set_borders_allbo_color_indexe( ip_borders_allbo_color_indexed ).
     ENDIF.
     IF ip_borders_allbo_color_theme IS SUPPLIED.
-      complete_style-borders-allborders-border_color-theme = ip_borders_allbo_color_theme.
-      complete_stylex-borders-allborders-border_color-theme = 'X'.
+      changer->set_borders_allbo_color_theme( ip_borders_allbo_color_theme ).
     ENDIF.
     IF ip_borders_allbo_color_tint IS SUPPLIED.
-      complete_style-borders-allborders-border_color-tint = ip_borders_allbo_color_tint.
-      complete_stylex-borders-allborders-border_color-tint = 'X'.
+      changer->set_borders_allbo_color_tint( ip_borders_allbo_color_tint ).
     ENDIF.
 
     IF ip_borders_diagonal_style IS SUPPLIED.
-      complete_style-borders-diagonal-border_style = ip_borders_diagonal_style.
-      complete_stylex-borders-diagonal-border_style = 'X'.
+      changer->set_borders_diagonal_style( ip_borders_diagonal_style ).
     ENDIF.
     IF ip_borders_diagonal_color IS SUPPLIED.
-      complete_style-borders-diagonal-border_color = ip_borders_diagonal_color.
-      complete_stylex-borders-diagonal-border_color-rgb = 'X'.
+      changer->set_borders_diagonal_color( ip_borders_diagonal_color ).
     ENDIF.
     IF ip_borders_diagonal_color_rgb IS SUPPLIED.
-      complete_style-borders-diagonal-border_color-rgb = ip_borders_diagonal_color_rgb.
-      complete_stylex-borders-diagonal-border_color-rgb = 'X'.
+      changer->set_borders_diagonal_color_rgb( ip_borders_diagonal_color_rgb ).
     ENDIF.
     IF ip_borders_diagonal_color_inde IS SUPPLIED.
-      complete_style-borders-diagonal-border_color-indexed = ip_borders_diagonal_color_inde.
-      complete_stylex-borders-diagonal-border_color-indexed = 'X'.
+      changer->set_borders_diagonal_color_ind( ip_borders_diagonal_color_inde ).
     ENDIF.
     IF ip_borders_diagonal_color_them IS SUPPLIED.
-      complete_style-borders-diagonal-border_color-theme = ip_borders_diagonal_color_them.
-      complete_stylex-borders-diagonal-border_color-theme = 'X'.
+      changer->set_borders_diagonal_color_the( ip_borders_diagonal_color_them ).
     ENDIF.
     IF ip_borders_diagonal_color_tint IS SUPPLIED.
-      complete_style-borders-diagonal-border_color-tint = ip_borders_diagonal_color_tint.
-      complete_stylex-borders-diagonal-border_color-tint = 'X'.
+      changer->set_borders_diagonal_color_tin( ip_borders_diagonal_color_tint ).
     ENDIF.
 
     IF ip_borders_down_style IS SUPPLIED.
-      complete_style-borders-down-border_style = ip_borders_down_style.
-      complete_stylex-borders-down-border_style = 'X'.
+      changer->set_borders_down_style( ip_borders_down_style ).
     ENDIF.
     IF ip_borders_down_color IS SUPPLIED.
-      complete_style-borders-down-border_color = ip_borders_down_color.
-      complete_stylex-borders-down-border_color-rgb = 'X'.
+      changer->set_borders_down_color( ip_borders_down_color ).
     ENDIF.
     IF ip_borders_down_color_rgb IS SUPPLIED.
-      complete_style-borders-down-border_color-rgb = ip_borders_down_color_rgb.
-      complete_stylex-borders-down-border_color-rgb = 'X'.
+      changer->set_borders_down_color_rgb( ip_borders_down_color_rgb ).
     ENDIF.
     IF ip_borders_down_color_indexed IS SUPPLIED.
-      complete_style-borders-down-border_color-indexed = ip_borders_down_color_indexed.
-      complete_stylex-borders-down-border_color-indexed = 'X'.
+      changer->set_borders_down_color_indexed( ip_borders_down_color_indexed ).
     ENDIF.
     IF ip_borders_down_color_theme IS SUPPLIED.
-      complete_style-borders-down-border_color-theme = ip_borders_down_color_theme.
-      complete_stylex-borders-down-border_color-theme = 'X'.
+      changer->set_borders_down_color_theme( ip_borders_down_color_theme ).
     ENDIF.
     IF ip_borders_down_color_tint IS SUPPLIED.
-      complete_style-borders-down-border_color-tint = ip_borders_down_color_tint.
-      complete_stylex-borders-down-border_color-tint = 'X'.
+      changer->set_borders_down_color_tint( ip_borders_down_color_tint ).
     ENDIF.
 
     IF ip_borders_left_style IS SUPPLIED.
-      complete_style-borders-left-border_style = ip_borders_left_style.
-      complete_stylex-borders-left-border_style = 'X'.
+      changer->set_borders_left_style( ip_borders_left_style ).
     ENDIF.
     IF ip_borders_left_color IS SUPPLIED.
-      complete_style-borders-left-border_color = ip_borders_left_color.
-      complete_stylex-borders-left-border_color-rgb = 'X'.
+      changer->set_borders_left_color( ip_borders_left_color ).
     ENDIF.
     IF ip_borders_left_color_rgb IS SUPPLIED.
-      complete_style-borders-left-border_color-rgb = ip_borders_left_color_rgb.
-      complete_stylex-borders-left-border_color-rgb = 'X'.
+      changer->set_borders_left_color_rgb( ip_borders_left_color_rgb ).
     ENDIF.
     IF ip_borders_left_color_indexed IS SUPPLIED.
-      complete_style-borders-left-border_color-indexed = ip_borders_left_color_indexed.
-      complete_stylex-borders-left-border_color-indexed = 'X'.
+      changer->set_borders_left_color_indexed( ip_borders_left_color_indexed ).
     ENDIF.
     IF ip_borders_left_color_theme IS SUPPLIED.
-      complete_style-borders-left-border_color-theme = ip_borders_left_color_theme.
-      complete_stylex-borders-left-border_color-theme = 'X'.
+      changer->set_borders_left_color_theme( ip_borders_left_color_theme ).
     ENDIF.
     IF ip_borders_left_color_tint IS SUPPLIED.
-      complete_style-borders-left-border_color-tint = ip_borders_left_color_tint.
-      complete_stylex-borders-left-border_color-tint = 'X'.
+      changer->set_borders_left_color_tint( ip_borders_left_color_tint ).
     ENDIF.
 
     IF ip_borders_right_style IS SUPPLIED.
-      complete_style-borders-right-border_style = ip_borders_right_style.
-      complete_stylex-borders-right-border_style = 'X'.
+      changer->set_borders_right_style( ip_borders_right_style ).
     ENDIF.
     IF ip_borders_right_color IS SUPPLIED.
-      complete_style-borders-right-border_color = ip_borders_right_color.
-      complete_stylex-borders-right-border_color-rgb = 'X'.
+      changer->set_borders_right_color( ip_borders_right_color ).
     ENDIF.
     IF ip_borders_right_color_rgb IS SUPPLIED.
-      complete_style-borders-right-border_color-rgb = ip_borders_right_color_rgb.
-      complete_stylex-borders-right-border_color-rgb = 'X'.
+      changer->set_borders_right_color_rgb( ip_borders_right_color_rgb ).
     ENDIF.
     IF ip_borders_right_color_indexed IS SUPPLIED.
-      complete_style-borders-right-border_color-indexed = ip_borders_right_color_indexed.
-      complete_stylex-borders-right-border_color-indexed = 'X'.
+      changer->set_borders_right_color_indexe( ip_borders_right_color_indexed ).
     ENDIF.
     IF ip_borders_right_color_theme IS SUPPLIED.
-      complete_style-borders-right-border_color-theme = ip_borders_right_color_theme.
-      complete_stylex-borders-right-border_color-theme = 'X'.
+      changer->set_borders_right_color_theme( ip_borders_right_color_theme ).
     ENDIF.
     IF ip_borders_right_color_tint IS SUPPLIED.
-      complete_style-borders-right-border_color-tint = ip_borders_right_color_tint.
-      complete_stylex-borders-right-border_color-tint = 'X'.
+      changer->set_borders_right_color_tint( ip_borders_right_color_tint ).
     ENDIF.
 
     IF ip_borders_top_style IS SUPPLIED.
-      complete_style-borders-top-border_style = ip_borders_top_style.
-      complete_stylex-borders-top-border_style = 'X'.
+      changer->set_borders_top_style( ip_borders_top_style ).
     ENDIF.
     IF ip_borders_top_color IS SUPPLIED.
-      complete_style-borders-top-border_color = ip_borders_top_color.
-      complete_stylex-borders-top-border_color-rgb = 'X'.
+      changer->set_borders_top_color( ip_borders_top_color ).
     ENDIF.
     IF ip_borders_top_color_rgb IS SUPPLIED.
-      complete_style-borders-top-border_color-rgb = ip_borders_top_color_rgb.
-      complete_stylex-borders-top-border_color-rgb = 'X'.
+      changer->set_borders_top_color_rgb( ip_borders_top_color_rgb ).
     ENDIF.
     IF ip_borders_top_color_indexed IS SUPPLIED.
-      complete_style-borders-top-border_color-indexed = ip_borders_top_color_indexed.
-      complete_stylex-borders-top-border_color-indexed = 'X'.
+      changer->set_borders_top_color_indexed( ip_borders_top_color_indexed ).
     ENDIF.
     IF ip_borders_top_color_theme IS SUPPLIED.
-      complete_style-borders-top-border_color-theme = ip_borders_top_color_theme.
-      complete_stylex-borders-top-border_color-theme = 'X'.
+      changer->set_borders_top_color_theme( ip_borders_top_color_theme ).
     ENDIF.
     IF ip_borders_top_color_tint IS SUPPLIED.
-      complete_style-borders-top-border_color-tint = ip_borders_top_color_tint.
-      complete_stylex-borders-top-border_color-tint = 'X'.
+      changer->set_borders_top_color_tint( ip_borders_top_color_tint ).
     ENDIF.
 
 
-* Now we have a completly filled styles.
-* This can be used to get the guid
-* Return guid if requested.  Might be used if copy&paste of styles is requested
-    ep_guid = me->excel->get_static_cellstyle_guid( ip_cstyle_complete  = complete_style
-                                                    ip_cstylex_complete = complete_stylex  ).
-    me->set_cell_style( ip_column = ip_column
-                        ip_row    = ip_row
-                        ip_style  = ep_guid ).
+    changer->apply( ip_worksheet = me
+                    ip_column    = ip_column
+                    ip_row       = ip_row ).
+
 
   ENDMETHOD.                    "CHANGE_CELL_STYLE
 

--- a/src/zif_excel_style_changer.intf.abap
+++ b/src/zif_excel_style_changer.intf.abap
@@ -1,0 +1,493 @@
+INTERFACE zif_excel_style_changer
+  PUBLIC .
+
+  METHODS apply
+    IMPORTING
+      ip_worksheet TYPE REF TO zcl_excel_worksheet
+      ip_column    TYPE simple
+      ip_row       TYPE zexcel_cell_row
+    RAISING
+      zcx_excel.
+  METHODS get_guid
+    RETURNING
+      VALUE(result) TYPE zexcel_cell_style.
+  METHODS set_complete
+    IMPORTING
+      ip_complete   TYPE zexcel_s_cstyle_complete
+      ip_xcomplete  TYPE zexcel_s_cstylex_complete
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_complete_font
+    IMPORTING
+      ip_font       TYPE zexcel_s_cstyle_font
+      ip_xfont      TYPE zexcel_s_cstylex_font OPTIONAL
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_complete_fill
+    IMPORTING
+      ip_fill       TYPE zexcel_s_cstyle_fill
+      ip_xfill      TYPE zexcel_s_cstylex_fill OPTIONAL
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_complete_borders
+    IMPORTING
+      ip_borders    TYPE zexcel_s_cstyle_borders
+      ip_xborders   TYPE zexcel_s_cstylex_borders OPTIONAL
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_complete_alignment
+    IMPORTING
+      ip_alignment  TYPE zexcel_s_cstyle_alignment
+      ip_xalignment TYPE zexcel_s_cstylex_alignment OPTIONAL
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_complete_protection
+    IMPORTING
+      ip_protection  TYPE zexcel_s_cstyle_protection
+      ip_xprotection TYPE zexcel_s_cstylex_protection OPTIONAL
+    RETURNING
+      VALUE(result)  TYPE REF TO zif_excel_style_changer.
+  METHODS set_complete_borders_all
+    IMPORTING
+      ip_borders_allborders  TYPE zexcel_s_cstyle_border
+      ip_xborders_allborders TYPE zexcel_s_cstylex_border OPTIONAL
+    RETURNING
+      VALUE(result)          TYPE REF TO zif_excel_style_changer.
+  METHODS set_complete_borders_diagonal
+    IMPORTING
+      ip_borders_diagonal  TYPE zexcel_s_cstyle_border
+      ip_xborders_diagonal TYPE zexcel_s_cstylex_border OPTIONAL
+    RETURNING
+      VALUE(result)        TYPE REF TO zif_excel_style_changer.
+  METHODS set_complete_borders_down
+    IMPORTING
+      ip_borders_down  TYPE zexcel_s_cstyle_border
+      ip_xborders_down TYPE zexcel_s_cstylex_border OPTIONAL
+    RETURNING
+      VALUE(result)    TYPE REF TO zif_excel_style_changer.
+  METHODS set_complete_borders_left
+    IMPORTING
+      ip_borders_left  TYPE zexcel_s_cstyle_border
+      ip_xborders_left TYPE zexcel_s_cstylex_border OPTIONAL
+    RETURNING
+      VALUE(result)    TYPE REF TO zif_excel_style_changer.
+  METHODS set_complete_borders_right
+    IMPORTING
+      ip_borders_right  TYPE zexcel_s_cstyle_border
+      ip_xborders_right TYPE zexcel_s_cstylex_border OPTIONAL
+    RETURNING
+      VALUE(result)     TYPE REF TO zif_excel_style_changer.
+  METHODS set_complete_borders_top
+    IMPORTING
+      ip_borders_top  TYPE zexcel_s_cstyle_border
+      ip_xborders_top TYPE zexcel_s_cstylex_border OPTIONAL
+    RETURNING
+      VALUE(result)   TYPE REF TO zif_excel_style_changer.
+  METHODS set_number_format
+    IMPORTING
+      value         TYPE zexcel_number_format
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_bold
+    IMPORTING
+      value         TYPE flag
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_color
+    IMPORTING
+      value         TYPE zexcel_s_style_color
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_color_rgb
+    IMPORTING
+      value         TYPE zexcel_style_color_argb
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_color_indexed
+    IMPORTING
+      value         TYPE zexcel_style_color_indexed
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_color_theme
+    IMPORTING
+      value         TYPE zexcel_style_color_theme
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_color_tint
+    IMPORTING
+      value         TYPE zexcel_style_color_tint
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_family
+    IMPORTING
+      value         TYPE zexcel_style_font_family
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_italic
+    IMPORTING
+      value         TYPE flag
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_name
+    IMPORTING
+      value         TYPE zexcel_style_font_name
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_scheme
+    IMPORTING
+      value         TYPE zexcel_style_font_scheme
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_size
+    IMPORTING
+      value         TYPE numeric
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_strikethrough
+    IMPORTING
+      value         TYPE flag
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_underline
+    IMPORTING
+      value         TYPE flag
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_font_underline_mode
+    IMPORTING
+      value         TYPE zexcel_style_font_underline
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_filltype
+    IMPORTING
+      value         TYPE zexcel_fill_type
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_rotation
+    IMPORTING
+      value         TYPE zexcel_rotation
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_fgcolor
+    IMPORTING
+      value         TYPE zexcel_s_style_color
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_fgcolor_rgb
+    IMPORTING
+      value         TYPE zexcel_style_color_argb
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_fgcolor_indexed
+    IMPORTING
+      value         TYPE zexcel_style_color_indexed
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_fgcolor_theme
+    IMPORTING
+      value         TYPE zexcel_style_color_theme
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_fgcolor_tint
+    IMPORTING
+      value         TYPE zexcel_style_color_tint
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_bgcolor
+    IMPORTING
+      value         TYPE zexcel_s_style_color
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_bgcolor_rgb
+    IMPORTING
+      value         TYPE zexcel_style_color_argb
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_bgcolor_indexed
+    IMPORTING
+      value         TYPE zexcel_style_color_indexed
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_bgcolor_theme
+    IMPORTING
+      value         TYPE zexcel_style_color_theme
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_bgcolor_tint
+    IMPORTING
+      value         TYPE zexcel_style_color_tint
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_gradtype_type
+    IMPORTING
+      value         TYPE zexcel_s_gradient_type-type
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_gradtype_degree
+    IMPORTING
+      value         TYPE zexcel_s_gradient_type-degree
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_gradtype_bottom
+    IMPORTING
+      value         TYPE zexcel_s_gradient_type-bottom
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_gradtype_left
+    IMPORTING
+      value         TYPE zexcel_s_gradient_type-left
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_gradtype_top
+    IMPORTING
+      value         TYPE zexcel_s_gradient_type-top
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_gradtype_right
+    IMPORTING
+      value         TYPE zexcel_s_gradient_type-right
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_gradtype_position1
+    IMPORTING
+      value         TYPE zexcel_s_gradient_type-position1
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_gradtype_position2
+    IMPORTING
+      value         TYPE zexcel_s_gradient_type-position2
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_fill_gradtype_position3
+    IMPORTING
+      value         TYPE zexcel_s_gradient_type-position3
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_diagonal_mode
+    IMPORTING
+      value         TYPE zexcel_diagonal
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_alignment_horizontal
+    IMPORTING
+      value         TYPE zexcel_alignment
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_alignment_vertical
+    IMPORTING
+      value         TYPE zexcel_alignment
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_alignment_textrotation
+    IMPORTING
+      value         TYPE zexcel_text_rotation
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_alignment_wraptext
+    IMPORTING
+      value         TYPE flag
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_alignment_shrinktofit
+    IMPORTING
+      value         TYPE flag
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_alignment_indent
+    IMPORTING
+      value         TYPE zexcel_indent
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_protection_hidden
+    IMPORTING
+      value         TYPE zexcel_cell_protection
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_protection_locked
+    IMPORTING
+      value         TYPE zexcel_cell_protection
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_allborders_style
+    IMPORTING
+      value         TYPE zexcel_border
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_allborders_color
+    IMPORTING
+      value         TYPE zexcel_s_style_color
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_allbo_color_rgb
+    IMPORTING
+      value         TYPE zexcel_style_color_argb
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_allbo_color_indexe
+    IMPORTING
+      value         TYPE zexcel_style_color_indexed
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_allbo_color_theme
+    IMPORTING
+      value         TYPE zexcel_style_color_theme
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_allbo_color_tint
+    IMPORTING
+      value         TYPE zexcel_style_color_tint
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_diagonal_style
+    IMPORTING
+      value         TYPE zexcel_border
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_diagonal_color
+    IMPORTING
+      value         TYPE zexcel_s_style_color
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_diagonal_color_rgb
+    IMPORTING
+      value         TYPE zexcel_style_color_argb
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_diagonal_color_ind
+    IMPORTING
+      value         TYPE zexcel_style_color_indexed
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_diagonal_color_the
+    IMPORTING
+      value         TYPE zexcel_style_color_theme
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_diagonal_color_tin
+    IMPORTING
+      value         TYPE zexcel_style_color_tint
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_down_style
+    IMPORTING
+      value         TYPE zexcel_border
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_down_color
+    IMPORTING
+      value         TYPE zexcel_s_style_color
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_down_color_rgb
+    IMPORTING
+      value         TYPE zexcel_style_color_argb
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_down_color_indexed
+    IMPORTING
+      value         TYPE zexcel_style_color_indexed
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_down_color_theme
+    IMPORTING
+      value         TYPE zexcel_style_color_theme
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_down_color_tint
+    IMPORTING
+      value         TYPE zexcel_style_color_tint
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_left_style
+    IMPORTING
+      value         TYPE zexcel_border
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_left_color
+    IMPORTING
+      value         TYPE zexcel_s_style_color
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_left_color_rgb
+    IMPORTING
+      value         TYPE zexcel_style_color_argb
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_left_color_indexed
+    IMPORTING
+      value         TYPE zexcel_style_color_indexed
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_left_color_theme
+    IMPORTING
+      value         TYPE zexcel_style_color_theme
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_left_color_tint
+    IMPORTING
+      value         TYPE zexcel_style_color_tint
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_right_style
+    IMPORTING
+      value         TYPE zexcel_border
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_right_color
+    IMPORTING
+      value         TYPE zexcel_s_style_color
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_right_color_rgb
+    IMPORTING
+      value         TYPE zexcel_style_color_argb
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_right_color_indexe
+    IMPORTING
+      value         TYPE zexcel_style_color_indexed
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_right_color_theme
+    IMPORTING
+      value         TYPE zexcel_style_color_theme
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_right_color_tint
+    IMPORTING
+      value         TYPE zexcel_style_color_tint
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_top_style
+    IMPORTING
+      value         TYPE zexcel_border
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_top_color
+    IMPORTING
+      value         TYPE zexcel_s_style_color
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_top_color_rgb
+    IMPORTING
+      value         TYPE zexcel_style_color_argb
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_top_color_indexed
+    IMPORTING
+      value         TYPE zexcel_style_color_indexed
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_top_color_theme
+    IMPORTING
+      value         TYPE zexcel_style_color_theme
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  METHODS set_borders_top_color_tint
+    IMPORTING
+      value         TYPE zexcel_style_color_tint
+    RETURNING
+      VALUE(result) TYPE REF TO zif_excel_style_changer.
+  DATA: complete_style   TYPE zexcel_s_cstyle_complete READ-ONLY,
+        complete_stylex  TYPE zexcel_s_cstylex_complete READ-ONLY.
+ENDINTERFACE.

--- a/src/zif_excel_style_changer.intf.abap
+++ b/src/zif_excel_style_changer.intf.abap
@@ -3,9 +3,11 @@ INTERFACE zif_excel_style_changer
 
   METHODS apply
     IMPORTING
-      ip_worksheet TYPE REF TO zcl_excel_worksheet
-      ip_column    TYPE simple
-      ip_row       TYPE zexcel_cell_row
+      ip_worksheet   TYPE REF TO zcl_excel_worksheet
+      ip_column      TYPE simple
+      ip_row         TYPE zexcel_cell_row
+    RETURNING
+      VALUE(ep_guid) TYPE zexcel_cell_style
     RAISING
       zcx_excel.
   METHODS get_guid
@@ -488,6 +490,6 @@ INTERFACE zif_excel_style_changer
       value         TYPE zexcel_style_color_tint
     RETURNING
       VALUE(result) TYPE REF TO zif_excel_style_changer.
-  DATA: complete_style   TYPE zexcel_s_cstyle_complete READ-ONLY,
-        complete_stylex  TYPE zexcel_s_cstylex_complete READ-ONLY.
+  DATA: complete_style  TYPE zexcel_s_cstyle_complete READ-ONLY,
+        complete_stylex TYPE zexcel_s_cstylex_complete READ-ONLY.
 ENDINTERFACE.

--- a/src/zif_excel_style_changer.intf.xml
+++ b/src/zif_excel_style_changer.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_EXCEL_STYLE_CHANGER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Excel style</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Creation of new class `zcl_excel_style_changer` and refactor of `change_cell_style` to use it. There's no fix, no feature change, it helps to go towards #524.

Future plan: with this new class, it will be easy to create a new method `change_area_style` so that to change the style of many cells at a time. That would permit to rewrite [`zdemo_excel40`](https://github.com/sapmentors/abap2xlsx/blob/master/src/demos/zdemo_excel40.prog.abap), for the exact same result, instead of calling `set_cell` and `change_cell_style` repeatedly for each cell in 100 rows * 20 columns, the methods `set_area` and `change_area_style` could be called once:
```abap
    lo_worksheet->set_area(
          ip_column_start = 1
          ip_column_end   = 20
          ip_row          = 1
          ip_row_to       = 100
          ip_formula      = 'CHAR(64+COLUMN())&TEXT(ROW(),"       ?0")' ).

    lo_changer = zcl_excel_style_changer=>create( lo_excel ).
    lo_changer->set_fill_filltype( zcl_excel_style_fill=>c_fill_solid ).
    lo_changer->set_fill_fgcolor_rgb( zcl_excel_style_color=>c_yellow ).
    lo_worksheet->change_area_style(
          ip_column_start = 1
          ip_column_end   = 20
          ip_row          = 1
          ip_row_to       = 3
          ip_changer      = lo_changer ).

    lo_changer = zcl_excel_style_changer=>create( lo_excel ).
    lo_changer->set_font_color_rgb( zcl_excel_style_color=>c_red ).
    lo_worksheet->change_area_style(
          ip_column_start = 1
          ip_column_end   = 4
          ip_row          = 1
          ip_row_to       = 100
          ip_changer      = lo_changer ).
```