### PR TITLE
Correcting broken links after moving of repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # abap2xlsx - Read and generate Excel Spreadsheets with ABAP
 
-For general information please refer to the blog series [abap2xlsx - Generate your professional Excel spreadsheet from ABAP](http://scn.sap.com/community/abap/blog/2010/07/12/abap2xlsx--generate-your-professional-excel-spreadsheet-from-abap) and the [documentation](https://abap2xlsx/.github.io/abap2xlsx/).
-Please refer to the official wiki for the [abapGit installation guide](https://abap2xlsx/.github.io/abap2xlsx/abapGit-installation).
+For general information please refer to the blog series [abap2xlsx - Generate your professional Excel spreadsheet from ABAP](http://scn.sap.com/community/abap/blog/2010/07/12/abap2xlsx--generate-your-professional-excel-spreadsheet-from-abap) and the [documentation](https://abap2xlsx.github.io/abap2xlsx/).
+Please refer to the official wiki for the [abapGit installation guide](https://abap2xlsx.github.io/abap2xlsx/abapGit-installation).
 
 For questions, bug reports and more information on contributing to the project, please refer to the [contributing guidelines](./CONTRIBUTING.md).


### PR DESCRIPTION
The link to the documentation and abapGit installation instructions are broken after the move.