### PR TITLE
ZABAPGIT_STANDALONE instead of ZABAPGIT_FULL

### DIFF
--- a/docs/abapGit-installation.md
+++ b/docs/abapGit-installation.md
@@ -4,7 +4,7 @@
 
 ## Procedure
 
-Execute abapGit using the report **ZABAPGIT_FULL**, click on *New Online*, fill the field *Git repository URL* with *https://github.com/abap2xlsx/abap2xlsx.git*, package with *$abap2xlsx* if you just want to test. If you want to transport abap2xlsx to production then use a non local package, for example ZABAP2XLSX. Click *Create package* if the package doesn't exist yet. Then click *Clone online repo*.
+Execute abapGit using the report **ZABAPGIT_STANDALONE**, click on *New Online*, fill the field *Git repository URL* with *https://github.com/abap2xlsx/abap2xlsx.git*, package with *$abap2xlsx* if you just want to test. If you want to transport abap2xlsx to production then use a non local package, for example ZABAP2XLSX. Click *Create package* if the package doesn't exist yet. Then click *Clone online repo*.
 
 ![abapGit New Online Repository](new-online-abap2xlsx.png)
 


### PR DESCRIPTION
[abapGit instructions](https://docs.abapgit.org/guide-install.html) say `create a new report named ZABAPGIT_STANDALONE (formerly ZABAPGIT_FULL)`