### PR TITLE
Update publishing-a-new-release.md

### DIFF
--- a/docs/contributing/publishing-a-new-release.md
+++ b/docs/contributing/publishing-a-new-release.md
@@ -2,16 +2,19 @@
 
 Let's create a release from time to time, every 1 or 2 months for instance, to contain enough changes, but not too much.
 
-Below are the notes taken while publishing the release `7.15.0`.
+Below are the notes taken while publishing the release `7.16.0`.
 
 Version numbering is based on [Semantic Versioning 2.0.0](https://semver.org/):
 - `7`: a major release. NB: it will probably not change as we don't want to "make incompatible API changes".
 - `15`: a minor release
 - `0`: patch level (bug fixes)
 
-Create a branch for this new release, change `version` in `zcl_excel` to indicate the new version number and push the changes to the repository
+Working directly on the upstream repository:
+- create a branch for this new release; suggested naming for the branch: your own prefix - slash - release - number. For example: abo/release7.16.0 OR sandraros/release7.16.0
+- change `version` in `zcl_excel` to indicate the new version number
+- push the changes to this new release branch
 
-With GitHub Desktop (or any Git console or Git user interface), [add the tag](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/managing-tags) `7.15.0` to this branch.
+With GitHub Desktop (or any Git console or Git user interface), [add the (lightweight) tag](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/managing-tags) `v7.16.0` to this branch; suggested naming for version-related tags is v + version number.
 
 Do a pull request.
 
@@ -21,7 +24,7 @@ Now [create the release in GitHub](https://docs.github.com/en/repositories/relea
 - Click "Releases"
 - Click "Draft a new release"
 - Click "Choose a tag"
-- Type the title, click "Auto-generate release notes" and click "Preview" to verify; you should have a list with the following items, edit as required:
+- Type the title, select the previous tag, click "Auto-generate release notes" and click "Preview" to verify; you should have a list with the changes from the previous release, edit as required: 
     - `+`: new feature
     - `*`: bug fix
     - `!`: feature modification

--- a/docs/contributing/publishing-a-new-release.md
+++ b/docs/contributing/publishing-a-new-release.md
@@ -6,7 +6,7 @@ Below are the notes taken while publishing the release `7.16.0`.
 
 Version numbering is based on [Semantic Versioning 2.0.0](https://semver.org/):
 - `7`: a major release. NB: it will probably not change as we don't want to "make incompatible API changes".
-- `15`: a minor release
+- `16`: a minor release
 - `0`: patch level (bug fixes)
 
 Working directly on the upstream repository:


### PR DESCRIPTION
- noted that tags should be created when working from upstream repository (they do not come via PR from outside, only from local branches apparently)
- added note regarding previous tag for auto-generation of release notes