### PR TITLE
UnitTests ltc_normalize_column_heading were broken

### DIFF
--- a/src/zcl_excel_worksheet.clas.testclasses.abap
+++ b/src/zcl_excel_worksheet.clas.testclasses.abap
@@ -124,39 +124,39 @@ CLASS ltc_check_overlapping DEFINITION FOR TESTING
 ENDCLASS.
 
 
-CLASS ltc_normalize_column_heading DEFINITION FOR TESTING
-    RISK LEVEL HARMLESS
-    DURATION SHORT.
+class ltc_normalize_column_heading definition for testing
+    risk level harmless
+    duration short.
 
-  PRIVATE SECTION.
-    TYPES : BEGIN OF ty_parameters,
-              BEGIN OF input,
-                default_descr TYPE c LENGTH 1,
-                field_catalog TYPE zexcel_t_fieldcatalog,
-              END OF input,
-              BEGIN OF output,
-                field_catalog TYPE zexcel_t_fieldcatalog,
-              END OF output,
-            END OF ty_parameters.
-    DATA:
-      cut TYPE REF TO zcl_excel_worksheet.  "class under test
+  private section.
 
-    METHODS setup.
-    METHODS:
-      prefer_small_text FOR TESTING RAISING cx_static_check,
-      prefer_medium_text FOR TESTING RAISING cx_static_check,
-      prefer_long_text FOR TESTING RAISING cx_static_check,
-      default_text_if_none FOR TESTING RAISING cx_static_check,
-      invalid_default_descr FOR TESTING RAISING cx_static_check.
+    data:
+      cut           type ref to zcl_excel_worksheet,  "class under test
+      default_descr type c length 1 value '?'.
 
-    METHODS assert
-      IMPORTING
-        input TYPE ty_parameters-input
-        exp   TYPE ty_parameters-output
-      RAISING
-        cx_static_check.
+    methods:
 
-ENDCLASS.
+      prefer_small_text for testing raising cx_static_check,
+      prefer_medium_text for testing raising cx_static_check,
+      prefer_long_text for testing raising cx_static_check,
+      default_text_if_none for testing raising cx_static_check,
+      invalid_default_descr for testing raising cx_static_check,
+
+      assert
+        importing
+          ip_scrtext_s   type scrtext_s optional
+          ip_scrtext_m   type scrtext_m optional
+          ip_scrtext_l   type scrtext_l optional
+          ip_colname_exp type zexcel_column_name optional,
+
+      assert_multi
+        importing
+          it_fc          type zexcel_t_fieldcatalog optional
+          it_colname_exp type stringtab optional,
+
+     setup.
+
+endclass.
 
 
 CLASS ltc_normalize_columnrow_param DEFINITION FOR TESTING
@@ -1010,220 +1010,181 @@ CLASS ltc_check_overlapping IMPLEMENTATION.
 ENDCLASS.
 
 
-CLASS ltc_normalize_column_heading IMPLEMENTATION.
+class ltc_normalize_column_heading implementation.
 
-  METHOD setup.
+  method prefer_small_text.
 
-    DATA: lo_excel TYPE REF TO zcl_excel.
+    default_descr = 'S'.
 
-    CREATE OBJECT lo_excel.
+    assert(
+      ip_scrtext_s   = 'Column1_S'
+      ip_scrtext_m   = 'Column1_M'
+      ip_scrtext_l   = 'Column1_L'
+      ip_colname_exp = 'Column1_S'
+    ).
 
-    TRY.
-        CREATE OBJECT cut
-          EXPORTING
-            ip_excel = lo_excel.
-      CATCH zcx_excel.
-        cl_abap_unit_assert=>fail( 'Could not create instance' ).
-    ENDTRY.
 
-  ENDMETHOD.
+    assert(
+      ip_scrtext_m   = 'Column1_M'
+      ip_scrtext_l   = 'Column1_L'
+      ip_colname_exp = 'Column1_M'
+    ).
 
-  METHOD prefer_small_text.
-    DATA: input TYPE ty_parameters-input,
-          exp   TYPE ty_parameters-output,
-          field TYPE zexcel_s_fieldcatalog.
 
-    input-default_descr = 'S'.
+    assert(
+      ip_scrtext_m   = 'Column1_M'
+      ip_colname_exp = 'Column1_M'
+    ).
 
-    field-dynpfld   = abap_true.
+    assert(
+      ip_scrtext_l   = 'Column1_L'
+      ip_colname_exp = 'Column1_L'
+    ).
 
-    field-scrtext_s = 'Column1_S'.
-    field-scrtext_m = 'Column1_M'.
-    field-scrtext_l = 'Column1_L'.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column1_S'.
-    APPEND field TO exp-field_catalog.
 
-    field-scrtext_s = ''.
-    field-scrtext_m = 'Column2_M'.
-    field-scrtext_l = 'Column2_L'.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column2_M'.
-    APPEND field TO exp-field_catalog.
+  endmethod.
 
-    field-scrtext_s = ''.
-    field-scrtext_m = 'Column3_M'.
-    field-scrtext_l = ''.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column3_M'.
-    APPEND field TO exp-field_catalog.
+  method prefer_medium_text.
 
-    field-scrtext_s = ''.
-    field-scrtext_m = ''.
-    field-scrtext_l = 'Column4_L'.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column4_L'.
-    APPEND field TO exp-field_catalog.
+    default_descr = 'M'.
 
-    assert( input = input exp = exp ).
+    assert(
+      ip_scrtext_s   = 'Column1_S'
+      ip_scrtext_m   = 'Column1_M'
+      ip_scrtext_l   = 'Column1_L'
+      ip_colname_exp = 'Column1_M' ).
 
-  ENDMETHOD.
+    assert(
+      ip_scrtext_s   = 'Column1_S'
+      ip_scrtext_l   = 'Column1_L'
+      ip_colname_exp = 'Column1_S' ).
 
-  METHOD prefer_medium_text.
-    DATA: input TYPE ty_parameters-input,
-          exp   TYPE ty_parameters-output,
-          field TYPE zexcel_s_fieldcatalog.
+    assert(
+      ip_scrtext_s   = 'Column1_S'
+      ip_colname_exp = 'Column1_S' ).
 
-    input-default_descr = 'M'.
+    assert(
+      ip_scrtext_s   = 'Column1_L'
+      ip_colname_exp = 'Column1_L' ).
 
-    field-dynpfld   = abap_true.
+  endmethod.
 
-    field-scrtext_s = 'Column1_S'.
-    field-scrtext_m = 'Column1_M'.
-    field-scrtext_l = 'Column1_L'.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column1_M'.
-    APPEND field TO exp-field_catalog.
+  method prefer_long_text.
 
-    field-scrtext_s = 'Column2_S'.
-    field-scrtext_m = ''.
-    field-scrtext_l = 'Column2_L'.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column2_S'.
-    APPEND field TO exp-field_catalog.
+    default_descr = 'L'.
 
-    field-scrtext_s = 'Column3_S'.
-    field-scrtext_m = ''.
-    field-scrtext_l = ''.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column3_S'.
-    APPEND field TO exp-field_catalog.
+    assert(
+      ip_scrtext_s   = 'Column1_S'
+      ip_scrtext_m   = 'Column1_M'
+      ip_scrtext_l   = 'Column1_L'
+      ip_colname_exp = 'Column1_L' ).
 
-    field-scrtext_s = ''.
-    field-scrtext_m = ''.
-    field-scrtext_l = 'Column4_L'.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column4_L'.
-    APPEND field TO exp-field_catalog.
+    assert(
+      ip_scrtext_s   = 'Column1_S'
+      ip_scrtext_m   = 'Column1_M'
+      ip_colname_exp = 'Column1_M' ).
 
-    assert( input = input exp = exp ).
+    assert(
+      ip_scrtext_s   = 'Column1_S'
+      ip_colname_exp = 'Column1_S' ).
 
-  ENDMETHOD.
 
-  METHOD prefer_long_text.
-    DATA: input TYPE ty_parameters-input,
-          exp   TYPE ty_parameters-output,
-          field TYPE zexcel_s_fieldcatalog.
+  endmethod.
 
-    input-default_descr = 'L'.
+  method default_text_if_none.
 
-    field-dynpfld   = abap_true.
+    default_descr = 'S'.
 
-    field-scrtext_s = 'Column1_S'.
-    field-scrtext_m = 'Column1_M'.
-    field-scrtext_l = 'Column1_L'.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column1_L'.
-    APPEND field TO exp-field_catalog.
+    assert_multi(
+      it_fc = value #(  (   ) (   )  )
+      it_colname_exp = value #(
+        ( `Column`  )
+        ( `Column 1` )
+      )
+    ).
 
-    field-scrtext_s = 'Column2_S'.
-    field-scrtext_m = 'Column2_M'.
-    field-scrtext_l = ''.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column2_M'.
-    APPEND field TO exp-field_catalog.
 
-    field-scrtext_s = 'Column3_S'.
-    field-scrtext_m = ''.
-    field-scrtext_l = ''.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column3_S'.
-    APPEND field TO exp-field_catalog.
+  endmethod.
 
-    assert( input = input exp = exp ).
+  method invalid_default_descr.
 
-  ENDMETHOD.
+    default_descr = '?'.
 
-  METHOD default_text_if_none.
-    DATA: input TYPE ty_parameters-input,
-          exp   TYPE ty_parameters-output,
-          field TYPE zexcel_s_fieldcatalog.
+    assert(
+      ip_scrtext_s   = 'Column1_S'
+      ip_scrtext_m   = 'Column1_M'
+      ip_scrtext_l   = 'Column1_L'
+      ip_colname_exp = 'Column1_M' ).
 
-    input-default_descr = 'S'.
+    assert(
+      ip_scrtext_s   = 'Column1_S'
+      ip_scrtext_l   = 'Column1_L'
+      ip_colname_exp = 'Column1_S' ).
 
-    field-dynpfld   = abap_true.
+    assert(
+      ip_scrtext_s   = 'Column1_S'
+      ip_colname_exp = 'Column1_S' ).
 
-    field-scrtext_s = ''.
-    field-scrtext_m = ''.
-    field-scrtext_l = ''.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column'.
-    APPEND field TO exp-field_catalog.
+    assert(
+      ip_scrtext_l   = 'Column1_L'
+      ip_colname_exp = 'Column1_L' ).
 
-    field-scrtext_s = ''.
-    field-scrtext_m = ''.
-    field-scrtext_l = ''.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column 1'.
-    APPEND field TO exp-field_catalog.
 
-    assert( input = input exp = exp ).
+  endmethod.
 
-  ENDMETHOD.
+  method assert.
 
-  METHOD invalid_default_descr.
-    DATA: input TYPE ty_parameters-input,
-          exp   TYPE ty_parameters-output,
-          field TYPE zexcel_s_fieldcatalog.
+    data(lt_fc) = value zexcel_t_fieldcatalog( (
+        dynpfld   = abap_true
+        scrtext_s = ip_scrtext_s
+        scrtext_m = ip_scrtext_m
+        scrtext_l = ip_scrtext_l
+    ) ).
 
-    input-default_descr = '?'.
+    data(lt_fc_result) = cut->normalize_column_heading_texts(
+      iv_default_descr = default_descr
+      it_field_catalog = lt_fc ).
 
-    field-dynpfld   = abap_true.
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_fc_result[ 1 ]-column_name
+      exp = ip_colname_exp
+      quit = if_abap_unit_constant=>quit-no
+    ).
 
-    field-scrtext_s = 'Column1_S'.
-    field-scrtext_m = 'Column1_M'.
-    field-scrtext_l = 'Column1_L'.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column1_M'.
-    APPEND field TO exp-field_catalog.
+  endmethod.
 
-    field-scrtext_s = 'Column2_S'.
-    field-scrtext_m = ''.
-    field-scrtext_l = 'Column2_L'.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column2_S'.
-    APPEND field TO exp-field_catalog.
+  method assert_multi.
 
-    field-scrtext_s = 'Column3_S'.
-    field-scrtext_m = ''.
-    field-scrtext_l = ''.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column3_S'.
-    APPEND field TO exp-field_catalog.
+    data(lt_fc) = it_fc.
+    modify lt_fc from value #( dynpfld = abap_true ) transporting dynpfld where dynpfld = space.
 
-    field-scrtext_s = ''.
-    field-scrtext_m = ''.
-    field-scrtext_l = 'Column4_L'.
-    APPEND field TO input-field_catalog.
-    field-scrtext_l = 'Column4_L'.
-    APPEND field TO exp-field_catalog.
+    data(lt_fc_result) = cut->normalize_column_heading_texts(
+      iv_default_descr = default_descr
+      it_field_catalog = lt_fc
+    ).
 
-    assert( input = input exp = exp ).
+    cl_abap_unit_assert=>assert_equals(
+      act = value stringtab( for r in lt_fc_result ( conv #( r-column_name ) ) )
+      exp = it_colname_exp
+      quit = if_abap_unit_constant=>quit-no
+    ).
 
-  ENDMETHOD.
+  endmethod.
 
-  METHOD assert.
-    DATA: act TYPE ty_parameters-output.
 
-    act-field_catalog = cut->normalize_column_heading_texts(
-                            iv_default_descr = input-default_descr
-                            it_field_catalog = input-field_catalog ).
+  method setup.
 
-    cl_abap_unit_assert=>assert_equals( exp = exp-field_catalog act = act-field_catalog ).
+    try.
+        data(lo_excel) = new zcl_excel( ).
+        cut = new #( lo_excel ).
+      catch zcx_excel into data(lo_ex).
+        cl_abap_unit_assert=>fail( |Could not create instance: { lo_ex->get_text(  ) }| ).
+    endtry.
 
-  ENDMETHOD.
+  endmethod.
 
-ENDCLASS.
+
+endclass.
 
 
 CLASS ltc_normalize_columnrow_param IMPLEMENTATION.

--- a/src/zcl_excel_worksheet.clas.testclasses.abap
+++ b/src/zcl_excel_worksheet.clas.testclasses.abap
@@ -1156,9 +1156,12 @@ CLASS ltc_normalize_column_heading IMPLEMENTATION.
       iv_default_descr = default_descr
       it_field_catalog = lt_fc ).
 
+    FIELD-SYMBOLS <ls_fc> TYPE zexcel_s_fieldcatalog.
+    READ TABLE lt_fc_result ASSIGNING <ls_fc> INDEX 1.
+
     cl_abap_unit_assert=>assert_equals(
-      act = lt_fc_result[ 1 ]-column_name
-      exp = ip_colname_exp
+      act  = <ls_fc>-column_name
+      exp  = ip_colname_exp
       quit = if_abap_unit_constant=>quit-no
     ).
 

--- a/src/zcl_excel_worksheet.clas.testclasses.abap
+++ b/src/zcl_excel_worksheet.clas.testclasses.abap
@@ -124,7 +124,7 @@ CLASS ltc_check_overlapping DEFINITION FOR TESTING
 ENDCLASS.
 
 
-class ltc_normalize_column_heading definition for testing
+CLASS ltc_normalize_column_heading DEFINITION FOR TESTING
     risk level harmless
     duration short.
 

--- a/src/zcl_excel_worksheet.clas.testclasses.abap
+++ b/src/zcl_excel_worksheet.clas.testclasses.abap
@@ -125,38 +125,38 @@ ENDCLASS.
 
 
 CLASS ltc_normalize_column_heading DEFINITION FOR TESTING
-    risk level harmless
-    duration short.
+    RISK LEVEL HARMLESS
+    DURATION SHORT.
 
-  private section.
+  PRIVATE SECTION.
 
-    data:
-      cut           type ref to zcl_excel_worksheet,  "class under test
-      default_descr type c length 1 value '?'.
+    DATA:
+      cut           TYPE REF TO zcl_excel_worksheet,  "class under test
+      default_descr TYPE c LENGTH 1 VALUE '?'.
 
-    methods:
+    METHODS:
 
-      prefer_small_text for testing raising cx_static_check,
-      prefer_medium_text for testing raising cx_static_check,
-      prefer_long_text for testing raising cx_static_check,
-      default_text_if_none for testing raising cx_static_check,
-      invalid_default_descr for testing raising cx_static_check,
+      prefer_small_text FOR TESTING RAISING cx_static_check,
+      prefer_medium_text FOR TESTING RAISING cx_static_check,
+      prefer_long_text FOR TESTING RAISING cx_static_check,
+      default_text_if_none FOR TESTING RAISING cx_static_check,
+      invalid_default_descr FOR TESTING RAISING cx_static_check,
 
       assert
-        importing
-          ip_scrtext_s   type scrtext_s optional
-          ip_scrtext_m   type scrtext_m optional
-          ip_scrtext_l   type scrtext_l optional
-          ip_colname_exp type zexcel_column_name optional,
+        IMPORTING
+          ip_scrtext_s   TYPE scrtext_s OPTIONAL
+          ip_scrtext_m   TYPE scrtext_m OPTIONAL
+          ip_scrtext_l   TYPE scrtext_l OPTIONAL
+          ip_colname_exp TYPE zexcel_column_name OPTIONAL,
 
       assert_multi
-        importing
-          it_fc          type zexcel_t_fieldcatalog optional
-          it_colname_exp type stringtab optional,
+        IMPORTING
+          it_fc          TYPE zexcel_t_fieldcatalog OPTIONAL
+          it_colname_exp TYPE stringtab OPTIONAL,
 
-     setup.
+      setup.
 
-endclass.
+ENDCLASS.
 
 
 CLASS ltc_normalize_columnrow_param DEFINITION FOR TESTING
@@ -1010,9 +1010,9 @@ CLASS ltc_check_overlapping IMPLEMENTATION.
 ENDCLASS.
 
 
-class ltc_normalize_column_heading implementation.
+CLASS ltc_normalize_column_heading IMPLEMENTATION.
 
-  method prefer_small_text.
+  METHOD prefer_small_text.
 
     default_descr = 'S'.
 
@@ -1042,9 +1042,9 @@ class ltc_normalize_column_heading implementation.
     ).
 
 
-  endmethod.
+  ENDMETHOD.
 
-  method prefer_medium_text.
+  METHOD prefer_medium_text.
 
     default_descr = 'M'.
 
@@ -1067,9 +1067,9 @@ class ltc_normalize_column_heading implementation.
       ip_scrtext_s   = 'Column1_L'
       ip_colname_exp = 'Column1_L' ).
 
-  endmethod.
+  ENDMETHOD.
 
-  method prefer_long_text.
+  METHOD prefer_long_text.
 
     default_descr = 'L'.
 
@@ -1089,24 +1089,24 @@ class ltc_normalize_column_heading implementation.
       ip_colname_exp = 'Column1_S' ).
 
 
-  endmethod.
+  ENDMETHOD.
 
-  method default_text_if_none.
+  METHOD default_text_if_none.
 
     default_descr = 'S'.
 
     assert_multi(
-      it_fc = value #(  (   ) (   )  )
-      it_colname_exp = value #(
+      it_fc = VALUE #(  (   ) (   )  )
+      it_colname_exp = VALUE #(
         ( `Column`  )
         ( `Column 1` )
       )
     ).
 
 
-  endmethod.
+  ENDMETHOD.
 
-  method invalid_default_descr.
+  METHOD invalid_default_descr.
 
     default_descr = '?'.
 
@@ -1130,18 +1130,18 @@ class ltc_normalize_column_heading implementation.
       ip_colname_exp = 'Column1_L' ).
 
 
-  endmethod.
+  ENDMETHOD.
 
-  method assert.
+  METHOD assert.
 
-    data(lt_fc) = value zexcel_t_fieldcatalog( (
+    DATA(lt_fc) = VALUE zexcel_t_fieldcatalog( (
         dynpfld   = abap_true
         scrtext_s = ip_scrtext_s
         scrtext_m = ip_scrtext_m
         scrtext_l = ip_scrtext_l
     ) ).
 
-    data(lt_fc_result) = cut->normalize_column_heading_texts(
+    DATA(lt_fc_result) = cut->normalize_column_heading_texts(
       iv_default_descr = default_descr
       it_field_catalog = lt_fc ).
 
@@ -1151,40 +1151,40 @@ class ltc_normalize_column_heading implementation.
       quit = if_abap_unit_constant=>quit-no
     ).
 
-  endmethod.
+  ENDMETHOD.
 
-  method assert_multi.
+  METHOD assert_multi.
 
-    data(lt_fc) = it_fc.
-    modify lt_fc from value #( dynpfld = abap_true ) transporting dynpfld where dynpfld = space.
+    DATA(lt_fc) = it_fc.
+    MODIFY lt_fc FROM VALUE #( dynpfld = abap_true ) TRANSPORTING dynpfld WHERE dynpfld = space.
 
-    data(lt_fc_result) = cut->normalize_column_heading_texts(
+    DATA(lt_fc_result) = cut->normalize_column_heading_texts(
       iv_default_descr = default_descr
       it_field_catalog = lt_fc
     ).
 
     cl_abap_unit_assert=>assert_equals(
-      act = value stringtab( for r in lt_fc_result ( conv #( r-column_name ) ) )
+      act = VALUE stringtab( FOR r IN lt_fc_result ( CONV #( r-column_name ) ) )
       exp = it_colname_exp
       quit = if_abap_unit_constant=>quit-no
     ).
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method setup.
+  METHOD setup.
 
-    try.
-        data(lo_excel) = new zcl_excel( ).
-        cut = new #( lo_excel ).
-      catch zcx_excel into data(lo_ex).
+    TRY.
+        DATA(lo_excel) = NEW zcl_excel( ).
+        cut = NEW #( lo_excel ).
+      CATCH zcx_excel INTO DATA(lo_ex).
         cl_abap_unit_assert=>fail( |Could not create instance: { lo_ex->get_text(  ) }| ).
-    endtry.
+    ENDTRY.
 
-  endmethod.
+  ENDMETHOD.
 
 
-endclass.
+ENDCLASS.
 
 
 CLASS ltc_normalize_columnrow_param IMPLEMENTATION.

--- a/src/zcl_excel_worksheet.clas.testclasses.abap
+++ b/src/zcl_excel_worksheet.clas.testclasses.abap
@@ -1166,9 +1166,12 @@ CLASS ltc_normalize_column_heading IMPLEMENTATION.
 
   METHOD assert_multi.
 
-    DATA lt_fc LIKE it_fc.
+    DATA:
+      lt_fc LIKE it_fc,
+      ls_fc LIKE LINE OF it_fc.
+    ls_fc-dynpfld = abap_true.
     lt_fc = it_fc.
-    MODIFY lt_fc FROM VALUE #( dynpfld = abap_true ) TRANSPORTING dynpfld WHERE dynpfld = space.
+    MODIFY lt_fc FROM ls_fc TRANSPORTING dynpfld WHERE dynpfld = space.
 
     DATA lt_fc_result TYPE zexcel_t_fieldcatalog.
     lt_fc_result = cut->normalize_column_heading_texts(
@@ -1189,7 +1192,6 @@ CLASS ltc_normalize_column_heading IMPLEMENTATION.
     ).
 
   ENDMETHOD.
-
 
   METHOD setup.
 

--- a/src/zcl_excel_worksheet.clas.testclasses.abap
+++ b/src/zcl_excel_worksheet.clas.testclasses.abap
@@ -1193,12 +1193,21 @@ CLASS ltc_normalize_column_heading IMPLEMENTATION.
 
   METHOD setup.
 
+    DATA:
+      lo_ex      TYPE REF TO zcx_excel,
+      lv_ex_text TYPE string,
+      lv_msg     TYPE string.
+
     TRY.
         DATA lo_excel TYPE REF TO zcl_excel.
         CREATE OBJECT lo_excel.
         CREATE OBJECT cut EXPORTING ip_excel = lo_excel.
-      CATCH zcx_excel INTO DATA(lo_ex).
-        cl_abap_unit_assert=>fail( |Could not create instance: { lo_ex->get_text(  ) }| ).
+      CATCH zcx_excel INTO lo_ex.
+        lv_ex_text = lo_ex->get_text( ).
+        CONCATENATE `Could not create instance:` lv_ex_text
+          INTO lv_msg
+          SEPARATED BY space.
+        cl_abap_unit_assert=>fail( lv_ex_text ).
     ENDTRY.
 
   ENDMETHOD.


### PR DESCRIPTION
After having introduced a new column `column_name` in the zexcel_s_fieldcatalog (in Commit bca6db9 by user @bigld ), the unit tests of class ltc_normalize_column_heading were broken: the test expectations should have been adapted to the new field `column_name`. 

To find broken unit tests after download of the latest abap2xlsx version is confusing, especially for newcomers. It is best practice, when performing changes on a class, to execute their abap unit tests before uploading them into github.

I have used the opportunity to refactor the test class  ltc_normalize_column_heading - the intentions of the tests should be better readable now.