### PR TITLE
Autofilter Solutions for excel writer

### DIFF
--- a/src/not_cloud/zcl_excel_converter.clas.abap
+++ b/src/not_cloud/zcl_excel_converter.clas.abap
@@ -1698,7 +1698,7 @@ CLASS zcl_excel_converter IMPLEMENTATION.
 
 * Let's check for filter.
     IF wo_autofilter IS BOUND.
-      ls_area-row_start = 1.
+      ls_area-row_start = w_row_int.
       lt_values = wo_autofilter->get_values( ) .
       SORT lt_values BY column ASCENDING.
       DESCRIBE TABLE lt_values LINES l_lines.

--- a/src/not_cloud/zcl_excel_converter_alv.clas.abap
+++ b/src/not_cloud/zcl_excel_converter_alv.clas.abap
@@ -388,11 +388,11 @@ CLASS zcl_excel_converter_alv IMPLEMENTATION.
 
   METHOD get_filter.
     TYPES: BEGIN OF ts_field_range,
-             fieldname TYPE lvc_fname,
+             fieldname TYPE fieldname,
              range_tab TYPE REF TO data,
            END OF ts_field_range.
 
-    DATA: ls_filt           TYPE lvc_s_filt,
+    DATA: ls_filt           LIKE LINE OF wt_filt,
           ls_filter         TYPE zexcel_s_converter_fil,
           lo_addit          TYPE REF TO cl_abap_elemdescr,
           lt_components_tab TYPE cl_abap_structdescr=>component_table,
@@ -401,7 +401,7 @@ CLASS zcl_excel_converter_alv IMPLEMENTATION.
           lo_struc          TYPE REF TO cl_abap_structdescr,
           lt_field_range    TYPE TABLE OF ts_field_range,
           ls_field_range    LIKE LINE OF lt_field_range,
-          lv_fieldname      TYPE lvc_fname.
+          lv_fieldname      TYPE fieldname.
 
     FIELD-SYMBOLS: <fs_tab>    TYPE STANDARD TABLE,
                    <fs_stab>   TYPE any,

--- a/src/not_cloud/zcl_excel_converter_alv.clas.abap
+++ b/src/not_cloud/zcl_excel_converter_alv.clas.abap
@@ -387,99 +387,126 @@ CLASS zcl_excel_converter_alv IMPLEMENTATION.
 
 
   METHOD get_filter.
-    DATA: ls_filt   TYPE lvc_s_filt,
-          l_line    TYPE i,
-          ls_filter TYPE zexcel_s_converter_fil.
-    DATA: lo_addit          TYPE REF TO cl_abap_elemdescr,
+    TYPES: BEGIN OF ts_field_range,
+             fieldname TYPE lvc_fname,
+             range_tab TYPE REF TO data,
+           END OF ts_field_range.
+
+    DATA: ls_filt           TYPE lvc_s_filt,
+          ls_filter         TYPE zexcel_s_converter_fil,
+          lo_addit          TYPE REF TO cl_abap_elemdescr,
           lt_components_tab TYPE cl_abap_structdescr=>component_table,
           ls_components     TYPE abap_componentdescr,
           lo_table          TYPE REF TO cl_abap_tabledescr,
           lo_struc          TYPE REF TO cl_abap_structdescr,
-          lo_trange         TYPE REF TO data,
-          lo_srange         TYPE REF TO data,
-          lo_ltabdata       TYPE REF TO data.
+          lt_field_range    TYPE TABLE OF ts_field_range,
+          ls_field_range    LIKE LINE OF lt_field_range,
+          lv_fieldname      TYPE lvc_fname.
 
     FIELD-SYMBOLS: <fs_tab>    TYPE STANDARD TABLE,
-                   <fs_ltab>   TYPE STANDARD TABLE,
                    <fs_stab>   TYPE any,
                    <fs>        TYPE any,
-                   <fs1>       TYPE any,
                    <fs_srange> TYPE any,
-                   <fs_trange> TYPE STANDARD TABLE.
+                   <fs_trange> TYPE STANDARD TABLE,
+                   <fs_field_range> LIKE LINE OF lt_field_range.
 
-    IF ws_option-filter = abap_false.
-      CLEAR et_filter.
+    CLEAR et_filter.
+    IF wt_filt IS INITIAL OR
+       ws_option-filter = abap_false.
       RETURN.
     ENDIF.
 
     ASSIGN xo_table->* TO <fs_tab>.
+    READ TABLE <fs_tab> ASSIGNING <fs_stab> INDEX 1.
+    IF sy-subrc <> 0.
+      RETURN.
+    ENDIF.
 
-    CREATE DATA lo_ltabdata LIKE <fs_tab>.
-    ASSIGN lo_ltabdata->* TO <fs_ltab>.
+    SORT wt_filt BY fieldname.
 
+* Range creation and range comparison must be done in two steps:
+* This is due to the fact, that range values might be applied
+* all together at once not value after value for a specific fieldname
+* --> Having multiple excluding values is a problem that would otherwise
+* occur...
+
+* 1. Step: Create the combined ranges for each fieldname...
     LOOP AT wt_filt INTO ls_filt.
-      LOOP AT <fs_tab> ASSIGNING <fs_stab>.
-        l_line = sy-tabix.
+      IF ls_filt-fieldname <> lv_fieldname.
+        lv_fieldname = ls_filt-fieldname.
+        UNASSIGN <fs_trange>.
         ASSIGN COMPONENT ls_filt-fieldname OF STRUCTURE <fs_stab> TO <fs>.
-        IF sy-subrc = 0.
-          IF l_line = 1.
-            CLEAR lt_components_tab.
-            ls_components-name   = 'SIGN'.
-            lo_addit            ?= cl_abap_typedescr=>describe_by_data( ls_filt-sign ).
-            ls_components-type   = lo_addit           .
-            INSERT ls_components INTO TABLE lt_components_tab.
-            ls_components-name   = 'OPTION'.
-            lo_addit            ?= cl_abap_typedescr=>describe_by_data( ls_filt-option ).
-            ls_components-type   = lo_addit           .
-            INSERT ls_components INTO TABLE lt_components_tab.
-            ls_components-name   = 'LOW'.
-            lo_addit            ?= cl_abap_typedescr=>describe_by_data( <fs> ).
-            ls_components-type   = lo_addit           .
-            INSERT ls_components INTO TABLE lt_components_tab.
-            ls_components-name   = 'HIGH'.
-            lo_addit            ?= cl_abap_typedescr=>describe_by_data( <fs> ).
-            ls_components-type   = lo_addit           .
-            INSERT ls_components INTO TABLE lt_components_tab.
-            "create new line type
-            TRY.
-                lo_struc = cl_abap_structdescr=>create( p_components = lt_components_tab
-                                                        p_strict     = abap_false ).
-              CATCH cx_sy_struct_creation.
-                CONTINUE.
-            ENDTRY.
-            lo_table = cl_abap_tabledescr=>create( lo_struc ).
+        CHECK sy-subrc = 0.
 
-            CREATE DATA lo_trange  TYPE HANDLE lo_table.
-            CREATE DATA lo_srange  TYPE HANDLE lo_struc.
+        IF lt_components_tab IS INITIAL.
+          ls_components-name   = 'SIGN'.
+          lo_addit            ?= cl_abap_typedescr=>describe_by_data( ls_filt-sign ).
+          ls_components-type   = lo_addit.
+          APPEND ls_components TO lt_components_tab.
+          ls_components-name   = 'OPTION'.
+          lo_addit            ?= cl_abap_typedescr=>describe_by_data( ls_filt-option ).
+          ls_components-type   = lo_addit.
+          APPEND ls_components TO lt_components_tab.
+        ELSE.
+          DELETE lt_components_tab FROM 3.
+        ENDIF.
 
-            ASSIGN lo_trange->* TO <fs_trange>.
-            ASSIGN lo_srange->* TO <fs_srange>.
+        lo_addit            ?= cl_abap_typedescr=>describe_by_data( <fs> ).
+        ls_components-type   = lo_addit.
+
+        ls_components-name   = 'LOW'.
+        APPEND ls_components TO lt_components_tab.
+        ls_components-name   = 'HIGH'.
+        APPEND ls_components TO lt_components_tab.
+        "create new line type
+        TRY.
+            lo_struc = cl_abap_structdescr=>create( p_components = lt_components_tab
+                                                    p_strict     = abap_false ).
+          CATCH cx_sy_struct_creation.
+            CONTINUE.
+        ENDTRY.
+        lo_table = cl_abap_tabledescr=>create( lo_struc ).
+
+        ls_field_range-fieldname = ls_filt-fieldname.
+        CREATE DATA ls_field_range-range_tab TYPE HANDLE lo_table.
+        APPEND ls_field_range TO lt_field_range.
+
+        ASSIGN ls_field_range-range_tab->* TO <fs_trange>.
+      ELSE.
+        CHECK <fs_trange> IS ASSIGNED.
+      ENDIF.
+
+      APPEND INITIAL LINE TO <fs_trange> ASSIGNING <fs_srange>.
+      ASSIGN COMPONENT 'SIGN'   OF STRUCTURE <fs_srange> TO <fs>.
+      <fs> = ls_filt-sign.
+      ASSIGN COMPONENT 'OPTION' OF STRUCTURE <fs_srange> TO <fs>.
+      <fs> = ls_filt-option.
+      ASSIGN COMPONENT 'LOW'    OF STRUCTURE <fs_srange> TO <fs>.
+      <fs> = ls_filt-low.
+      ASSIGN COMPONENT 'HIGH'   OF STRUCTURE <fs_srange> TO <fs>.
+      <fs> = ls_filt-high.
+    ENDLOOP.
+
+    IF lt_field_range IS INITIAL.
+      RETURN.
+    ENDIF.
+
+* 2. Step: Now apply the fieldname ranges afterwards...
+    LOOP AT <fs_tab> ASSIGNING <fs_stab>.
+      ls_filter-rownumber = sy-tabix.
+      LOOP AT lt_field_range ASSIGNING <fs_field_range>.
+        ASSIGN COMPONENT <fs_field_range>-fieldname OF STRUCTURE <fs_stab> TO <fs>.
+        ASSIGN <fs_field_range>-range_tab->* TO <fs_trange>.
+        IF <fs> IN <fs_trange>.
+          IF ws_option-filter = abap_true.
+            ls_filter-columnname = <fs_field_range>-fieldname.
+            INSERT ls_filter INTO TABLE et_filter.
           ENDIF.
-          CLEAR <fs_trange>.
-          ASSIGN COMPONENT 'SIGN'   OF STRUCTURE  <fs_srange> TO <fs1>.
-          <fs1> = ls_filt-sign.
-          ASSIGN COMPONENT 'OPTION' OF STRUCTURE  <fs_srange> TO <fs1>.
-          <fs1> = ls_filt-option.
-          ASSIGN COMPONENT 'LOW'   OF STRUCTURE  <fs_srange> TO <fs1>.
-          <fs1> = ls_filt-low.
-          ASSIGN COMPONENT 'HIGH'   OF STRUCTURE  <fs_srange> TO <fs1>.
-          <fs1> = ls_filt-high.
-          INSERT <fs_srange> INTO TABLE <fs_trange>.
-          IF <fs> IN <fs_trange>.
-            IF ws_option-filter = abap_true.
-              ls_filter-rownumber   = l_line.
-              ls_filter-columnname  = ls_filt-fieldname.
-              INSERT ls_filter INTO TABLE et_filter.
-            ELSE.
-              INSERT <fs_stab> INTO TABLE <fs_ltab>.
-            ENDIF.
-          ENDIF.
+        ELSEIF ws_option-filter = abap_undefined.
+          DELETE <fs_tab>.
+          EXIT.  "--> next xo_table line
         ENDIF.
       ENDLOOP.
-      IF ws_option-filter = abap_undefined.
-        <fs_tab> = <fs_ltab>.
-        CLEAR <fs_ltab>.
-      ENDIF.
     ENDLOOP.
 
   ENDMETHOD.

--- a/src/zcl_excel_autofilter.clas.abap
+++ b/src/zcl_excel_autofilter.clas.abap
@@ -13,13 +13,13 @@ CLASS zcl_excel_autofilter DEFINITION
       BEGIN OF ts_filter,
         column           TYPE zexcel_cell_column,
         rule             TYPE tv_filter_rule,
-        t_values         TYPE HASHED TABLE OF zexcel_cell_value WITH UNIQUE KEY table_line,
+        t_values         TYPE SORTED TABLE OF zexcel_cell_value WITH UNIQUE KEY table_line,
         tr_textfilter1   TYPE RANGE OF string,
         logical_operator TYPE tv_logical_operator,
         tr_textfilter2   TYPE RANGE OF string,
       END OF ts_filter .
     TYPES:
-      tt_filters TYPE HASHED TABLE OF ts_filter WITH UNIQUE KEY column .
+      tt_filters TYPE SORTED TABLE OF ts_filter WITH UNIQUE KEY column .
 
     DATA filter_area TYPE zexcel_s_autofilter_area .
     CONSTANTS mc_filter_rule_single_values TYPE tv_filter_rule VALUE 'single_values'. "#EC NOTEXT
@@ -414,11 +414,6 @@ CLASS zcl_excel_autofilter IMPLEMENTATION.
       filter_area-col_end   = l_col .
     ENDIF.
 
-    IF filter_area-row_start > filter_area-row_end.
-      ls_original_filter_area = filter_area.
-      filter_area-row_start = ls_original_filter_area-row_end.
-      filter_area-row_end = ls_original_filter_area-row_start.
-    ENDIF.
     IF filter_area-row_start < 1.
       filter_area-row_start = 1.
     ENDIF.
@@ -432,6 +427,11 @@ CLASS zcl_excel_autofilter IMPLEMENTATION.
     IF filter_area-col_end > l_col OR
        filter_area-col_end < 1.
       filter_area-col_end = l_col.
+    ENDIF.
+    IF filter_area-row_start > filter_area-row_end.
+      ls_original_filter_area = filter_area.
+      filter_area-row_start = ls_original_filter_area-row_end.
+      filter_area-row_end = ls_original_filter_area-row_start.
     ENDIF.
     IF filter_area-col_start > filter_area-col_end.
       filter_area-col_start = filter_area-col_end.

--- a/src/zcl_excel_autofilter.clas.abap
+++ b/src/zcl_excel_autofilter.clas.abap
@@ -207,10 +207,6 @@ CLASS zcl_excel_autofilter IMPLEMENTATION.
 
   METHOD is_row_hidden.
 
-
-    DATA: lr_filter TYPE REF TO ts_filter,
-          lv_col    TYPE i.
-
     FIELD-SYMBOLS: <ls_filter> TYPE ts_filter.
 
     rv_is_hidden = abap_false.
@@ -219,29 +215,25 @@ CLASS zcl_excel_autofilter IMPLEMENTATION.
 * 1st row of filter area is never hidden, because here the filter
 * symbol is being shown
 *--------------------------------------------------------------------*
-    IF iv_row = me->filter_area-row_start.
+    IF iv_row <= me->filter_area-row_start OR
+       iv_row >  me->filter_area-row_end.
       RETURN.
     ENDIF.
 
 
-    lv_col = me->filter_area-col_start.
-
-
-    WHILE lv_col <= me->filter_area-col_end.
-
-      lr_filter = me->get_column_filter( lv_col ).
-      ASSIGN lr_filter->* TO <ls_filter>.
+    LOOP AT mt_filters ASSIGNING <ls_filter> WHERE column >= me->filter_area-col_start
+                                               AND column <= me->filter_area-col_end.
 
       CASE <ls_filter>-rule.
 
         WHEN mc_filter_rule_single_values.
           rv_is_hidden = me->is_row_hidden_single_values( iv_row    = iv_row
-                                                          iv_col    = lv_col
+                                                          iv_col    = <ls_filter>-column
                                                           is_filter = <ls_filter> ).
 
         WHEN mc_filter_rule_text_pattern.
           rv_is_hidden = me->is_row_hidden_text_pattern(  iv_row    = iv_row
-                                                          iv_col    = lv_col
+                                                          iv_col    = <ls_filter>-column
                                                           is_filter = <ls_filter> ).
 
       ENDCASE.
@@ -250,10 +242,7 @@ CLASS zcl_excel_autofilter IMPLEMENTATION.
         RETURN.
       ENDIF.
 
-
-      ADD 1 TO lv_col.
-
-    ENDWHILE.
+    ENDLOOP.
 
 
   ENDMETHOD.


### PR DESCRIPTION
Continued from pull request https://github.com/abap2xlsx/abap2xlsx/pull/985 and trying to solve https://github.com/abap2xlsx/abap2xlsx/pull/1017, but i can not reproduce any problems with date format.

Update zcl_excel_converter_alv->get_filter to avoid too many values.

Update zcl_excel_writer_2007->create_xl_sheet_sheet_data to work with multiple values for multiple columns.
Old field l_autofilter_hidden = 'X' is now represented by an entry for each filter column in table lt_cols2match.

If you use for example ZDEMO_EXCEL32 for testing be careful using ZDEMO_EXCEL33 at the same time.
Unfortunately ZDEMO_EXCEL33 calls method zcl_excel_converter->set_option instead of using the is_option parameter of the immediately following zcl_excel_converter->convert method call.
So these options, which don't contain filter = 'X', remain and the defaults of method zcl_excel_converter->init_option are not used for any further convert method call with ALV (like in ZDEMO_EXCEL32) until the 'EXCEL_username' record is deleted from database INDX.
Otherwise the only workaround is the explicit use of the is_option parameter of convert method call like attached to https://github.com/abap2xlsx/abap2xlsx/pull/1017.