### PR TITLE
abaplint: update msag_consistency rule settings

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -136,7 +136,9 @@
     "local_class_naming": false,
     "main_file_contents": true,
     "message_exists": false,
-    "msag_consistency": true,
+    "msag_consistency": {
+      "numericParamters": false
+    },
     "newline_between_methods": false,
     "no_public_attributes": false,
     "object_naming": {


### PR DESCRIPTION
to not require numeric parameters

or https://github.com/abaplint/abaplint/pull/3119 will break `main`