### PR TITLE
Unused calls/variables about cl_xml_document

### DIFF
--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -2666,7 +2666,6 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
   METHOD create_xl_drawings_vml.
 
     DATA:
-      lo_xml_document TYPE REF TO cl_xml_document,
       ld_stream       TYPE string.
 
 
@@ -2676,11 +2675,6 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 
 * BODY
     ld_stream = set_vml_string( ).
-
-    CREATE OBJECT lo_xml_document.
-    CALL METHOD lo_xml_document->parse_string
-      EXPORTING
-        stream = ld_stream.
 
     CALL FUNCTION 'SCMS_STRING_TO_XSTRING'
       EXPORTING
@@ -3334,8 +3328,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
       ls_odd_footer   TYPE zexcel_s_worksheet_head_foot,
       ls_even_header  TYPE zexcel_s_worksheet_head_foot,
       ls_even_footer  TYPE zexcel_s_worksheet_head_foot,
-      lv_content      TYPE string,
-      lo_xml_document TYPE REF TO cl_xml_document.
+      lv_content      TYPE string.
 
 
 * INIT_RESULT
@@ -3382,11 +3375,6 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
     CONCATENATE lv_content
                 ld_7
            INTO lv_content.
-
-    CREATE OBJECT lo_xml_document.
-    CALL METHOD lo_xml_document->parse_string
-      EXPORTING
-        stream = lv_content.
 
     CALL FUNCTION 'SCMS_STRING_TO_XSTRING'
       EXPORTING

--- a/src/zcl_excel_writer_xlsm.clas.abap
+++ b/src/zcl_excel_writer_xlsm.clas.abap
@@ -262,8 +262,7 @@ CLASS zcl_excel_writer_xlsm IMPLEMENTATION.
           lo_ostream       TYPE REF TO if_ixml_ostream,
           lo_renderer      TYPE REF TO if_ixml_renderer.
 
-    DATA: lv_subrc       TYPE sysubrc,
-          lv_contenttype TYPE string.
+    DATA: lv_contenttype TYPE string.
 
 **********************************************************************
 * STEP 3: Create standard contentType
@@ -273,7 +272,7 @@ CLASS zcl_excel_writer_xlsm IMPLEMENTATION.
 * STEP 2: modify XML adding the extension bin definition
 
     CREATE OBJECT lo_document_xml.
-    lv_subrc = lo_document_xml->parse_xstring( ep_content ).
+    lo_document_xml->parse_xstring( ep_content ).
 
     lo_document ?= lo_document_xml->m_document.
     lo_element_root = lo_document->if_ixml_node~get_first_child( ).
@@ -342,7 +341,6 @@ CLASS zcl_excel_writer_xlsm IMPLEMENTATION.
 
     DATA: lv_xml_node_ridx_id TYPE string,
           lv_size             TYPE i,
-          lv_subrc            TYPE sysubrc,
           lv_syindex(2)       TYPE c.
 
 **********************************************************************
@@ -353,7 +351,7 @@ CLASS zcl_excel_writer_xlsm IMPLEMENTATION.
 * STEP 2: modify XML adding the vbaProject relation
 
     CREATE OBJECT lo_document_xml.
-    lv_subrc = lo_document_xml->parse_xstring( ep_content ).
+    lo_document_xml->parse_xstring( ep_content ).
 
     lo_document ?= lo_document_xml->m_document.
     lo_element_root = lo_document->if_ixml_node~get_first_child( ).
@@ -406,8 +404,6 @@ CLASS zcl_excel_writer_xlsm IMPLEMENTATION.
           lo_ostream       TYPE REF TO if_ixml_ostream,
           lo_renderer      TYPE REF TO if_ixml_renderer.
 
-    DATA: lv_subrc      TYPE sysubrc.
-
 **********************************************************************
 * STEP 3: Create standard relationship
     ep_content = super->create_xl_sheet( io_worksheet = io_worksheet
@@ -417,7 +413,7 @@ CLASS zcl_excel_writer_xlsm IMPLEMENTATION.
 * STEP 2: modify XML adding the vbaProject relation
 
     CREATE OBJECT lo_document_xml.
-    lv_subrc = lo_document_xml->parse_xstring( ep_content ).
+    lo_document_xml->parse_xstring( ep_content ).
 
     lo_document ?= lo_document_xml->m_document.
     lo_element_root = lo_document->if_ixml_node~get_first_child( ).
@@ -458,8 +454,6 @@ CLASS zcl_excel_writer_xlsm IMPLEMENTATION.
           lo_ostream       TYPE REF TO if_ixml_ostream,
           lo_renderer      TYPE REF TO if_ixml_renderer.
 
-    DATA: lv_subrc      TYPE sysubrc.
-
 **********************************************************************
 * STEP 3: Create standard relationship
     ep_content = super->create_xl_workbook( ).
@@ -468,7 +462,7 @@ CLASS zcl_excel_writer_xlsm IMPLEMENTATION.
 * STEP 2: modify XML adding the vbaProject relation
 
     CREATE OBJECT lo_document_xml.
-    lv_subrc = lo_document_xml->parse_xstring( ep_content ).
+    lo_document_xml->parse_xstring( ep_content ).
 
     lo_document ?= lo_document_xml->m_document.
     lo_element_root = lo_document->if_ixml_node~get_first_child( ).


### PR DESCRIPTION
1. After calling the method `parse_string` (of `cl_xml_document`), the document instance is not used → removing the call and the unused variable.
2. The return code of method call `parse_xstring` (of `cl_xml_document`) is not used → removing the unused variable.
   NB: it's needed to keep the calls to `parse_xstring` as they are followed by the use of the instantiated document instance.