### PR TITLE
Header/footer images and comments together create wrong file destinations in sheet#.xml.rels

### DIFF
--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -4122,11 +4122,12 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 
 **********************************************************************
 * header footer image
-    IF iv_hdft_vmlindex > 0.. "Header or footer image exist
-      ADD 1 TO lv_relation_id.
+    IF iv_hdft_vmlindex > 0. "Header or footer image exist
       " Drawing for comment/header/footer
       lo_element = lo_document->create_simple_element( name   = lc_xml_node_relationship
                                                        parent = lo_document ).
+      ADD 1 TO lv_relation_id.
+
       lv_value = lv_relation_id.
       CONDENSE lv_value.
       CONCATENATE 'rId' lv_value INTO lv_value.

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -145,10 +145,10 @@ CLASS zcl_excel_writer_2007 DEFINITION
     METHODS create_xl_sheet_rels
       IMPORTING
         !io_worksheet     TYPE REF TO zcl_excel_worksheet
-        !iv_drawing_index TYPE i optional
-        !iv_comment_index TYPE i optional
-        !iv_cmnt_vmlindex type I optional
-        !iv_hdft_vmlindex type I optional
+        !iv_drawing_index TYPE i OPTIONAL
+        !iv_comment_index TYPE i OPTIONAL
+        !iv_cmnt_vmlindex TYPE i OPTIONAL
+        !iv_hdft_vmlindex TYPE i OPTIONAL
       RETURNING
         VALUE(ep_content) TYPE xstring .
     METHODS create_xl_styles
@@ -325,10 +325,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
           lo_iterator         TYPE REF TO zcl_excel_collection_iterator,
           lo_nested_iterator  TYPE REF TO zcl_excel_collection_iterator,
           lo_table            TYPE REF TO zcl_excel_table,
-          lo_drawing          TYPE REF TO zcl_excel_drawing,
-          lo_drawings         TYPE REF TO zcl_excel_drawings,
-          lo_comment          TYPE REF TO zcl_excel_comment,   " (+) Issue #180
-          lo_comments         TYPE REF TO zcl_excel_comments.  " (+) Issue #180
+          lo_drawing          TYPE REF TO zcl_excel_drawing.
 
     DATA: lv_content                TYPE xstring,
           lv_active                 TYPE flag,
@@ -4008,8 +4005,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 
     DATA: lv_value         TYPE string,
           lv_relation_id   TYPE i,
-          lv_index_str     TYPE string,
-          lv_comment_index TYPE i.
+          lv_index_str     TYPE string.
 
 **********************************************************************
 * STEP 1: Create [Content_Types].xml into the root of the ZIP
@@ -4053,10 +4049,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
     ENDWHILE.
 
 * drawing
-    DATA: lo_drawings TYPE REF TO zcl_excel_drawings.
-
-    lo_drawings = io_worksheet->get_drawings( ).
-    IF lo_drawings->is_empty( ) = abap_false.
+    IF iv_drawing_index > 0.
       lo_element = lo_document->create_simple_element( name   = lc_xml_node_relationship
                                                        parent = lo_document ).
       ADD 1 TO lv_relation_id.
@@ -4080,18 +4073,11 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
     ENDIF.
 
 * Begin - Add - Issue #180
-    DATA: lo_comments  TYPE REF TO zcl_excel_comments.
-
-    lv_comment_index = iv_comment_index.
-
-    lo_comments = io_worksheet->get_comments( ).
-    IF lo_comments->is_empty( ) = abap_false.
+    IF iv_cmnt_vmlindex > 0 AND iv_comment_index > 0.
       " Drawing for comment
       lo_element = lo_document->create_simple_element( name   = lc_xml_node_relationship
                                                        parent = lo_document ).
-
       ADD 1 TO lv_relation_id.
-      ADD 1 TO lv_comment_index.
 
       lv_value = lv_relation_id.
       CONDENSE lv_value.
@@ -4101,7 +4087,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
       lo_element->set_attribute_ns( name  = lc_xml_attr_type
                                     value = lc_xml_node_rid_drawing_cmt_tp ).
 
-      lv_index_str = iv_comment_index.
+      lv_index_str = iv_cmnt_vmlindex.
       CONDENSE lv_index_str NO-GAPS.
       lv_value = me->cl_xl_drawing_for_comments.
       REPLACE 'xl' WITH '..' INTO lv_value.
@@ -4136,9 +4122,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 
 **********************************************************************
 * header footer image
-    DATA: lt_drawings TYPE zexcel_t_drawings.
-    lt_drawings = io_worksheet->get_header_footer_drawings( ).
-    IF lines( lt_drawings ) > 0. "Header or footer image exist
+    IF iv_hdft_vmlindex > 0.. "Header or footer image exist
       ADD 1 TO lv_relation_id.
       " Drawing for comment/header/footer
       lo_element = lo_document->create_simple_element( name   = lc_xml_node_relationship
@@ -4151,7 +4135,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
       lo_element->set_attribute_ns( name  = lc_xml_attr_type
                                     value = lc_xml_node_rid_drawing_cmt_tp ).
 
-      lv_index_str = lv_comment_index.
+      lv_index_str = iv_hdft_vmlindex.
       CONDENSE lv_index_str NO-GAPS.
       lv_value = me->cl_xl_drawing_for_comments.
       REPLACE 'xl' WITH '..' INTO lv_value.


### PR DESCRIPTION
Hello,

Try to add any comment in the second sheet of demo program ZTEST_EXCEL_IMAGE_HEADER and run it.
You will not succeed.

For comments the same index is used for the xl/comments.xml file and the xl/drawings/vmlDrawing.vml file.
This works as long as the comments are the only user of vml drawings.
But now there are header/footer images which also uses vml drawings.

In the example above however the first vml index is already used by first sheet's header/footer if the comment is created.
That means that the comment needs comments1.xml and vmlDrawing2.vml. This is not possible with current ABAP2XLSX.
And you cannot use comment2.xml leaving a gap, because comment files in [Content_Types].xml are counted from 1 without gaps.

The relationship between comment index and corresponding vml index must be separated.
We need one comment counter for xl/comments#.xml only and one vml counter
supplying vml index for comments and vml index for header/footer.

The following changes are to make in zcl_excel_writer_2007's methods create and create_xl_sheet_rels:

The new idea of calling method create_xl_sheet_rels is not to pass counters as currently but indices which are filled with
current counter values if needed or with initial value if not. The number of parameters to pass increases to four.
So you can use them in this method as a mark to create the respective relation or not without any need to call the according
get data method for empty check again.

I attach an excel file with the content to achieve:
[Image_Header_Footer_with_comment.xlsx](https://github.com/abap2xlsx/abap2xlsx/files/14893321/Image_Header_Footer_with_comment.xlsx)

Demo program ZTEST_EXCEL_IMAGE_HEADER with a minimum change for demonstration:

```abap
*&---------------------------------------------------------------------*
*& Report  ZTEST_EXCEL_IMAGE_HEADER
*&
*&---------------------------------------------------------------------*
*&
*&
*&---------------------------------------------------------------------*

REPORT ztest_excel_image_header.

DATA: lo_excel     TYPE REF TO zcl_excel,
      lo_worksheet TYPE REF TO zcl_excel_worksheet,
      lo_drawing   TYPE REF TO zcl_excel_drawing,
      ls_key       TYPE wwwdatatab,
      ls_header    TYPE zexcel_s_worksheet_head_foot,
      ls_footer    TYPE zexcel_s_worksheet_head_foot,
      lv_content   TYPE xstring.

CONSTANTS: gc_save_file_name TYPE string VALUE 'Image_Header_Footer.xlsx'.
INCLUDE zdemo_excel_outputopt_incl.

START-OF-SELECTION.

  " Creates active sheet
  CREATE OBJECT lo_excel.

**********************************************************************
*** Header Center
  " create global drawing, set position and media from web repository
  lo_drawing = lo_excel->add_new_drawing( ip_type = zcl_excel_drawing=>type_image_header_footer ).

  ls_key-relid = 'MI'.
  ls_key-objid = 'SAPLOGO.GIF'.
  lo_drawing->set_media_www( ip_key = ls_key
                            ip_width = 166
                            ip_height = 75 ).
**********************************************************************
  ls_header-center_image = lo_drawing.


**********************************************************************
*** Header Left
  " create global drawing, set position and media from web repository
  lo_drawing = lo_excel->add_new_drawing( ip_type = zcl_excel_drawing=>type_image_header_footer ).

  ls_key-relid = 'MI'.
  ls_key-objid = 'SAPLOGO.GIF'.
  lo_drawing->set_media_www( ip_key = ls_key
                             ip_width = 166
                             ip_height = 75 ).


  ls_header-left_image = ls_footer-left_image = lo_drawing.
  ls_header-left_value = 'Hallo'.
  lo_worksheet = lo_excel->get_active_worksheet( ).

  lo_worksheet->sheet_setup->set_header_footer( ip_odd_header = ls_header
                                                ip_odd_footer = ls_footer ).

**********************************************************************
*** Normal Image
  " create global drawing, set position and media from web repository
  lo_drawing = lo_excel->add_new_drawing( ).
  lo_drawing->set_position( ip_from_row = 3
                            ip_from_col = 'B' ).

  ls_key-relid = 'MI'.
  ls_key-objid = 'SAPLOGO.GIF'.
  lo_drawing->set_media_www( ip_key = ls_key
                             ip_width = 166
                             ip_height = 75 ).

  " assign drawing to the worksheet
  lo_worksheet->add_drawing( lo_drawing ).

**********************************************************************
**********************************************************************
* New sheet
  lo_worksheet = lo_excel->add_new_worksheet( 'Sheet2' ).

  " Add some content otherwise the error "nothing to be printed" is shown
  lo_worksheet->set_cell( ip_column = 'B' ip_row = 3 ip_value = 'Hello world' ).

**** Adding a comment in this sheet for demonstration ****
  DATA lo_comment TYPE REF TO zcl_excel_comment.
  lo_comment = lo_excel->add_new_comment( ).
  lo_comment->set_text( ip_ref = 'B3' ip_text = 'Just a comment' ).
  lo_worksheet->add_comment( lo_comment ).

**********************************************************************
*** Header Left
  " create global drawing, set position and media from web repository
  lo_drawing = lo_excel->add_new_drawing( ip_type = zcl_excel_drawing=>type_image_header_footer ).

  ls_key-relid = 'MI'.
  ls_key-objid = 'SAPLOGO.GIF'.
  lo_drawing->set_media_www( ip_key = ls_key
                             ip_width = 166
                             ip_height = 75 ).


  CLEAR ls_header.
  ls_header-left_image = ls_footer-left_image = lo_drawing.

  lo_worksheet->sheet_setup->set_header_footer( ip_odd_header = ls_header ).


*** Create output
  lcl_output=>output( lo_excel ).
```
