### PR TITLE
Add possibility to change the size of the comments.

### DIFF
--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -5,41 +5,43 @@ CLASS zcl_excel_comment DEFINITION
 
   PUBLIC SECTION.
 
-    CONSTANTS default_right_column TYPE i VALUE 4.          "#EC NOTEXT
-    CONSTANTS default_bottom_row TYPE i VALUE 15.           "#EC NOTEXT
+    CONSTANTS default_right_column TYPE i VALUE 4.  "#EC NOTEXT
+    CONSTANTS default_bottom_row   TYPE i VALUE 15. "#EC NOTEXT
 
     METHODS constructor .
-    METHODS get_name
+    METHODS get_bottom_row
       RETURNING
-        VALUE(r_name) TYPE string .
+        VALUE(rp_result) TYPE i .
     METHODS get_index
       RETURNING
         VALUE(rp_index) TYPE string .
+    METHODS get_name
+      RETURNING
+        VALUE(r_name) TYPE string .
     METHODS get_ref
       RETURNING
         VALUE(rp_ref) TYPE string .
+    METHODS get_right_column
+      RETURNING
+        VALUE(rp_result) TYPE i .
     METHODS get_text
       RETURNING
         VALUE(rp_text) TYPE string .
     METHODS set_text
       IMPORTING
-        !ip_text TYPE string
-        !ip_ref  TYPE string OPTIONAL
+        !ip_text         TYPE string
+        !ip_ref          TYPE string OPTIONAL
         !ip_right_column TYPE i OPTIONAL
-        !ip_bottom_row TYPE i OPTIONAL .
-    METHODS get_position
-      EXPORTING
-        !ep_right_column TYPE i
-        !ep_bottom_row TYPE i .
+        !ip_bottom_row   TYPE i OPTIONAL .
 
   PROTECTED SECTION.
   PRIVATE SECTION.
 
+    DATA bottom_row TYPE i .
     DATA index TYPE string .
     DATA ref TYPE string .
-    DATA text TYPE string .
     DATA right_column TYPE i .
-    DATA bottom_row TYPE i .
+    DATA text TYPE string .
 ENDCLASS.
 
 
@@ -49,6 +51,11 @@ CLASS zcl_excel_comment IMPLEMENTATION.
 
   METHOD constructor.
 
+  ENDMETHOD.
+
+
+  METHOD get_bottom_row.
+    rp_result = bottom_row.
   ENDMETHOD.
 
 
@@ -67,6 +74,11 @@ CLASS zcl_excel_comment IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD get_right_column.
+    rp_result = right_column.
+  ENDMETHOD.
+
+
   METHOD get_text.
     rp_text = me->text.
   ENDMETHOD.
@@ -79,30 +91,17 @@ CLASS zcl_excel_comment IMPLEMENTATION.
       me->ref = ip_ref.
     ENDIF.
 
-  IF ip_right_column IS SUPPLIED.
-    me->right_column = ip_right_column.
-  ENDIF.
+    IF ip_right_column IS NOT INITIAL.
+      me->right_column = ip_right_column.
+    ELSE.
+      me->right_column = default_right_column.
+    ENDIF.
 
-  IF ip_bottom_row IS SUPPLIED.
-    me->bottom_row = ip_bottom_row.
-  ENDIF.
-
+    IF ip_bottom_row IS NOT INITIAL.
+      me->bottom_row = ip_bottom_row.
+    ELSE.
+      me->bottom_row = default_bottom_row.
+    ENDIF.
   ENDMETHOD.
-
-METHOD get_position.
-
-  IF right_column IS NOT INITIAL.
-    ep_right_column = right_column.
-  ELSE.
-    ep_right_column = default_right_column. "Default right_column
-  ENDIF.
-
-  IF bottom_row IS NOT INITIAL.
-    ep_bottom_row = bottom_row.
-  ELSE.
-    ep_bottom_row = default_bottom_row. "Default bottom_row
-  ENDIF.
-
-ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -5,6 +5,9 @@ CLASS zcl_excel_comment DEFINITION
 
   PUBLIC SECTION.
 
+  constants DEFAULT_WIDTH type I value 2. "#EC NOTEXT
+  constants DEFAULT_HEIGHT type I value 15. "#EC NOTEXT
+
     METHODS constructor .
     METHODS get_name
       RETURNING
@@ -22,12 +25,23 @@ CLASS zcl_excel_comment DEFINITION
       IMPORTING
         !ip_text TYPE string
         !ip_ref  TYPE string OPTIONAL .
+  methods SET_SIZE
+    importing
+      !IP_WIDTH type I optional
+      !IP_HEIGHT type I optional .
+  methods GET_SIZE
+    exporting
+      !EP_WIDTH type I
+      !EP_HEIGHT type I .
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 
     DATA index TYPE string .
     DATA ref TYPE string .
     DATA text TYPE string .
+  data WIDTH type I .
+  data HEIGHT type I .
 ENDCLASS.
 
 

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -29,10 +29,10 @@ CLASS zcl_excel_comment DEFINITION
     IMPORTING
       !ip_width TYPE i OPTIONAL
       !ip_height TYPE i OPTIONAL .
-  methods GET_SIZE
-    exporting
-      !EP_WIDTH type I
-      !EP_HEIGHT type I .
+  METHODS get_size
+    EXPORTING
+      !ep_width TYPE i
+      !ep_height TYPE i .
 
   PROTECTED SECTION.
   PRIVATE SECTION.

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -5,7 +5,7 @@ CLASS zcl_excel_comment DEFINITION
 
   PUBLIC SECTION.
 
-  CONSTANTS default_width TYPE i VALUE 4. "#EC NOTEXT
+  CONSTANTS default_width TYPE i VALUE 2. "#EC NOTEXT
   CONSTANTS default_height TYPE i VALUE 15. "#EC NOTEXT
 
     METHODS constructor .

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -81,4 +81,33 @@ CLASS zcl_excel_comment IMPLEMENTATION.
       me->ref = ip_ref.
     ENDIF.
   ENDMETHOD.
+
+METHOD set_size.
+
+  IF ip_width IS SUPPLIED.
+    width = ip_width.
+  ENDIF.
+
+  IF ip_height IS SUPPLIED.
+    height = ip_height.
+  ENDIF.
+
+ENDMETHOD.
+
+method GET_SIZE.
+
+  IF width IS NOT INITIAL.
+    ep_width = width.
+  ELSE.
+    ep_width = default_width. "Default width
+  ENDIF.
+
+  IF height IS NOT INITIAL.
+    ep_height = height.
+  ELSE.
+    ep_height = default_height. "Default height
+  ENDIF.
+
+endmethod.
+
 ENDCLASS.

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -5,7 +5,7 @@ CLASS zcl_excel_comment DEFINITION
 
   PUBLIC SECTION.
 
-  constants DEFAULT_WIDTH type I value 2. "#EC NOTEXT
+  CONSTANTS default_width TYPE i VALUE 2. "#EC NOTEXT
   constants DEFAULT_HEIGHT type I value 15. "#EC NOTEXT
 
     METHODS constructor .

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -41,7 +41,7 @@ CLASS zcl_excel_comment DEFINITION
     DATA ref TYPE string .
     DATA text TYPE string .
     DATA width TYPE i .
-    DATA height TYPE I .
+    DATA height TYPE i .
 ENDCLASS.
 
 

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -5,7 +5,7 @@ CLASS zcl_excel_comment DEFINITION
 
   PUBLIC SECTION.
 
-  CONSTANTS default_width TYPE i VALUE 2. "#EC NOTEXT
+  CONSTANTS default_width TYPE i VALUE 4. "#EC NOTEXT
   CONSTANTS default_height TYPE i VALUE 15. "#EC NOTEXT
 
     METHODS constructor .

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -25,10 +25,10 @@ CLASS zcl_excel_comment DEFINITION
       IMPORTING
         !ip_text TYPE string
         !ip_ref  TYPE string OPTIONAL .
-  methods SET_SIZE
-    importing
-      !IP_WIDTH type I optional
-      !IP_HEIGHT type I optional .
+  METHODS set_size
+    IMPORTING
+      !ip_width TYPE i OPTIONAL
+      !ip_height TYPE i OPTIONAL .
   methods GET_SIZE
     exporting
       !EP_WIDTH type I

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -6,7 +6,7 @@ CLASS zcl_excel_comment DEFINITION
   PUBLIC SECTION.
 
   CONSTANTS default_width TYPE i VALUE 2. "#EC NOTEXT
-  constants DEFAULT_HEIGHT type I value 15. "#EC NOTEXT
+  CONSTANTS default_height TYPE i VALUE 15. "#EC NOTEXT
 
     METHODS constructor .
     METHODS get_name

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -40,7 +40,7 @@ CLASS zcl_excel_comment DEFINITION
     DATA index TYPE string .
     DATA ref TYPE string .
     DATA text TYPE string .
-  data WIDTH type I .
+  DATA width TYPE i .
   data HEIGHT type I .
 ENDCLASS.
 

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -24,11 +24,10 @@ CLASS zcl_excel_comment DEFINITION
     METHODS set_text
       IMPORTING
         !ip_text TYPE string
-        !ip_ref  TYPE string OPTIONAL .
-  METHODS set_size
-    IMPORTING
-      !ip_width TYPE i OPTIONAL
-      !ip_height TYPE i OPTIONAL .
+        !ip_ref  TYPE string OPTIONAL
+        !ip_width TYPE i OPTIONAL
+        !ip_height TYPE i OPTIONAL .
+
   METHODS get_size
     EXPORTING
       !ep_width TYPE i
@@ -80,19 +79,16 @@ CLASS zcl_excel_comment IMPLEMENTATION.
     IF ip_ref IS SUPPLIED.
       me->ref = ip_ref.
     ENDIF.
-  ENDMETHOD.
-
-METHOD set_size.
 
   IF ip_width IS SUPPLIED.
-    width = ip_width.
+    me->width = ip_width.
   ENDIF.
 
   IF ip_height IS SUPPLIED.
-    height = ip_height.
+    me->height = ip_height.
   ENDIF.
 
-ENDMETHOD.
+  ENDMETHOD.
 
 METHOD get_size.
 

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -94,7 +94,7 @@ METHOD set_size.
 
 ENDMETHOD.
 
-METHOD GET_SIZE.
+METHOD get_size.
 
   IF width IS NOT INITIAL.
     ep_width = width.

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -40,8 +40,8 @@ CLASS zcl_excel_comment DEFINITION
     DATA index TYPE string .
     DATA ref TYPE string .
     DATA text TYPE string .
-  DATA width TYPE i .
-  data HEIGHT type I .
+    DATA width TYPE i .
+    DATA height TYPE I .
 ENDCLASS.
 
 
@@ -94,7 +94,7 @@ METHOD set_size.
 
 ENDMETHOD.
 
-method GET_SIZE.
+METHOD GET_SIZE.
 
   IF width IS NOT INITIAL.
     ep_width = width.
@@ -108,6 +108,6 @@ method GET_SIZE.
     ep_height = default_height. "Default height
   ENDIF.
 
-endmethod.
+ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -38,8 +38,8 @@ CLASS zcl_excel_comment DEFINITION
     DATA index TYPE string .
     DATA ref TYPE string .
     DATA text TYPE string .
-  DATA right_column TYPE i .
-  data BOTTOM_ROW type I .
+    DATA right_column TYPE i .
+    DATA bottom_row TYPE i .
 ENDCLASS.
 
 

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -5,8 +5,8 @@ CLASS zcl_excel_comment DEFINITION
 
   PUBLIC SECTION.
 
-  CONSTANTS default_width TYPE i VALUE 4. "#EC NOTEXT
-  CONSTANTS default_height TYPE i VALUE 15. "#EC NOTEXT
+    CONSTANTS default_right_column TYPE i VALUE 4.          "#EC NOTEXT
+    CONSTANTS default_bottom_row TYPE i VALUE 15.           "#EC NOTEXT
 
     METHODS constructor .
     METHODS get_name
@@ -25,13 +25,12 @@ CLASS zcl_excel_comment DEFINITION
       IMPORTING
         !ip_text TYPE string
         !ip_ref  TYPE string OPTIONAL
-        !ip_width TYPE i OPTIONAL
-        !ip_height TYPE i OPTIONAL .
-
-  METHODS get_size
-    EXPORTING
-      !ep_width TYPE i
-      !ep_height TYPE i .
+        !ip_right_column TYPE i OPTIONAL
+        !ip_bottom_row TYPE i OPTIONAL .
+    METHODS get_position
+      EXPORTING
+        !ep_right_column TYPE i
+        !ep_bottom_row TYPE i .
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -39,8 +38,8 @@ CLASS zcl_excel_comment DEFINITION
     DATA index TYPE string .
     DATA ref TYPE string .
     DATA text TYPE string .
-    DATA width TYPE i .
-    DATA height TYPE i .
+  data RIGHT_COLUMN type I .
+  data BOTTOM_ROW type I .
 ENDCLASS.
 
 
@@ -80,28 +79,28 @@ CLASS zcl_excel_comment IMPLEMENTATION.
       me->ref = ip_ref.
     ENDIF.
 
-  IF ip_width IS SUPPLIED.
-    me->width = ip_width.
+  IF ip_right_column IS SUPPLIED.
+    me->right_column = ip_right_column.
   ENDIF.
 
-  IF ip_height IS SUPPLIED.
-    me->height = ip_height.
+  IF ip_bottom_row IS SUPPLIED.
+    me->bottom_row = ip_bottom_row.
   ENDIF.
 
   ENDMETHOD.
 
-METHOD get_size.
+METHOD GET_POSITION.
 
-  IF width IS NOT INITIAL.
-    ep_width = width.
+  IF right_column IS NOT INITIAL.
+    ep_right_column = right_column.
   ELSE.
-    ep_width = default_width. "Default width
+    ep_right_column = default_right_column. "Default right_column
   ENDIF.
 
-  IF height IS NOT INITIAL.
-    ep_height = height.
+  IF bottom_row IS NOT INITIAL.
+    ep_bottom_row = bottom_row.
   ELSE.
-    ep_height = default_height. "Default height
+    ep_bottom_row = default_bottom_row. "Default bottom_row
   ENDIF.
 
 ENDMETHOD.

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -89,7 +89,7 @@ CLASS zcl_excel_comment IMPLEMENTATION.
 
   ENDMETHOD.
 
-METHOD GET_POSITION.
+METHOD get_position.
 
   IF right_column IS NOT INITIAL.
     ep_right_column = right_column.

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -38,7 +38,7 @@ CLASS zcl_excel_comment DEFINITION
     DATA index TYPE string .
     DATA ref TYPE string .
     DATA text TYPE string .
-  data RIGHT_COLUMN type I .
+  DATA right_column TYPE i .
   data BOTTOM_ROW type I .
 ENDCLASS.
 

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -3304,7 +3304,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 *--------------------------------------------------------------------*
     DATA:
        lv_anchor     TYPE string,
-       lv_height     type i,
+       lv_height     TYPE i,
        lv_width      TYPE i,
        lv_height_str type string,
        lv_width_str  TYPE string.

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -3310,7 +3310,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
        lv_width_str  TYPE string.
 
     CONSTANTS:
-     lc_anchor_init TYPE string VALUE  '0, 1, 11, 10, &width&, 31, &height&, 9'.
+     lc_anchor_init TYPE string VALUE  '2, 15, 11, 10, &width&, 31, &height&, 9'.
 
     CALL METHOD lo_comment->get_size
       IMPORTING

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -3306,7 +3306,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
        lv_anchor     TYPE string,
        lv_height     TYPE i,
        lv_width      TYPE i,
-       lv_height_str type string,
+       lv_height_str TYPE string,
        lv_width_str  TYPE string.
 
     CONSTANTS:

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -3303,6 +3303,10 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 * Ricardo R. - 2024.05.02
 * https://github.com/abap2xlsx/abap2xlsx/pull/1219
 *--------------------------------------------------------------------*
+* Anchor represents 4 pairs of numbers:
+* ( left column, left offset ), ( top row, top offset ),
+* ( right column, right offset ), ( bottom row, botton offset )
+*--------------------------------------------------------------------*
     DATA:
        lv_anchor         TYPE string,
        lv_bottom_row     TYPE i,
@@ -3322,8 +3326,8 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
     lv_bottom_row_str = lv_bottom_row.
 
     lv_anchor = lc_anchor_init.
-    REPLACE '&right_col&'  WITH lv_bottom_row_str INTO lv_anchor.
-    REPLACE '&bottom_row&' WITH lv_right_col_str INTO lv_anchor.
+    REPLACE '&right_col&'  WITH lv_right_col_str INTO lv_anchor.
+    REPLACE '&bottom_row&' WITH lv_bottom_row_str INTO lv_anchor.
 
     lo_element_anchor->set_value( lv_anchor ).
 

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -3301,31 +3301,33 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 
 *--------------------------------------------------------------------*
 * Ricardo R. - 2024.05.02
+* https://github.com/abap2xlsx/abap2xlsx/pull/1219
 *--------------------------------------------------------------------*
     DATA:
-       lv_anchor     TYPE string,
-       lv_height     TYPE i,
-       lv_width      TYPE i,
-       lv_height_str TYPE string,
-       lv_width_str  TYPE string.
+       lv_anchor         TYPE string,
+       lv_bottom_row     TYPE i,
+       lv_right_col      TYPE i,
+       lv_bottom_row_str TYPE string,
+       lv_right_col_str  TYPE string.
 
     CONSTANTS:
-     lc_anchor_init TYPE string VALUE  '2, 15, 11, 10, &width&, 31, &height&, 9'.
+     lc_anchor_init TYPE string VALUE  '2, 15, 11, 10, &right_col&, 31, &bottom_row&, 9'.
 
-    CALL METHOD lo_comment->get_size
+    CALL METHOD lo_comment->get_position
       IMPORTING
-        ep_width  = lv_width
-        ep_height = lv_height.
+        ep_right_column = lv_right_col
+        ep_bottom_row   = lv_bottom_row.
 
-    lv_width_str  = lv_width.
-    lv_height_str = lv_height.
+    lv_right_col_str  = lv_right_col.
+    lv_bottom_row_str = lv_bottom_row.
 
     lv_anchor = lc_anchor_init.
-    REPLACE '&height&' WITH lv_height_str INTO lv_anchor.
-    REPLACE '&width&' WITH lv_width_str INTO lv_anchor.
+    REPLACE '&right_col&'  WITH lv_bottom_row_str INTO lv_anchor.
+    REPLACE '&bottom_row&' WITH lv_right_col_str INTO lv_anchor.
+
     lo_element_anchor->set_value( lv_anchor ).
 
-*    lo_element_anchor->set_value( '2, 15, 11, 10, 4, 31, 15, 9' ). "Original line
+**    lo_element_anchor->set_value( '2, 15, 11, 10, 4, 31, 15, 9' ). "Original line
 *--------------------------------------------------------------------*
 
       lo_element_clientdata->append_child( new_child = lo_element_anchor ).

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -3297,7 +3297,37 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
       lo_element_clientdata->append_child( new_child = lo_element_sizewithcells ).
       lo_element_anchor = lo_document->create_simple_element( name   = lc_xml_node_anchor
                                                               parent = lo_document ).
-      lo_element_anchor->set_value( '2, 15, 11, 10, 4, 31, 15, 9' ).
+
+
+*--------------------------------------------------------------------*
+* Ricardo R. - 2024.05.02
+*--------------------------------------------------------------------*
+    DATA:
+       lv_anchor     TYPE string,
+       lv_height     type i,
+       lv_width      TYPE i,
+       lv_height_str type string,
+       lv_width_str  TYPE string.
+
+    CONSTANTS:
+     lc_anchor_init TYPE string VALUE  '0, 1, 11, 10, &width&, 31, &height&, 9'.
+
+    CALL METHOD lo_comment->get_size
+      IMPORTING
+        ep_width  = lv_width
+        ep_height = lv_height.
+
+    lv_width_str  = lv_width.
+    lv_height_str = lv_height.
+
+    lv_anchor = lc_anchor_init.
+    REPLACE '&height&' WITH lv_height_str INTO lv_anchor.
+    REPLACE '&width&' WITH lv_width_str INTO lv_anchor.
+    lo_element_anchor->set_value( lv_anchor ).
+
+*    lo_element_anchor->set_value( '2, 15, 11, 10, 4, 31, 15, 9' ). "Original line
+*--------------------------------------------------------------------*      
+
       lo_element_clientdata->append_child( new_child = lo_element_anchor ).
       lo_element_autofill = lo_document->create_simple_element( name   = lc_xml_node_autofill
                                                                 parent = lo_document ).

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -3326,7 +3326,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
     lo_element_anchor->set_value( lv_anchor ).
 
 *    lo_element_anchor->set_value( '2, 15, 11, 10, 4, 31, 15, 9' ). "Original line
-*--------------------------------------------------------------------*      
+*--------------------------------------------------------------------*
 
       lo_element_clientdata->append_child( new_child = lo_element_anchor ).
       lo_element_autofill = lo_document->create_simple_element( name   = lc_xml_node_autofill


### PR DESCRIPTION
To fix #1221.

Changed class ZCL_EXCEL_COMMENT to change the method SET_TEXT adding two new OPTIONAL parameters: IP_RIGHT_COLUMN and IP_BOTTOM_ROW and add a new method: GET_POSITION.
And changed method CREATE_XL_DRAWING_FOR_COMMENTS of class ZCL_EXCEL_WRITER_2007 to read the size of the comments.

With this you can now set the size of the comments like this:


```
  DATA:
   lv_Comment              TYPE string,
   lo_comment              TYPE REF TO zcl_excel_comment.

  lv_Comment = 'Don Quijote de la Mancha.'.

  lo_comment = lo_excel->add_new_comment( ).
  lo_comment->set_text( ip_ref = 'D10' ip_text = lv_Comment ip_right_column = 5 ip_botom_row = 15 ).
  lo_worksheet->add_comment( lo_comment ).
```


![image](https://github.com/abap2xlsx/abap2xlsx/assets/168567887/ed104382-0f8e-413e-85c3-636e889114ea)


```
  DATA:
   lv_Comment              TYPE string,
   lo_comment              TYPE REF TO zcl_excel_comment.

  lv_Comment = 'En un lugar de la Mancha, de cuyo nombre no quiero acordarme, no ha mucho tiempo que vivía un hidalgo de los de lanza en astillero, adarga antigua, rocín flaco y galgo corredor.'.

  lo_comment = lo_excel->add_new_comment( ).
  lo_comment->set_text( ip_ref = 'D10' ip_text = lv_Comment  ip_right_column = 10 ip_bottom_row = 30 ).
  lo_worksheet->add_comment( lo_comment ).
```

![image](https://github.com/abap2xlsx/abap2xlsx/assets/168567887/b16b7fab-2ad8-4211-977c-354b6e34c6f6)



![image](https://github.com/abap2xlsx/abap2xlsx/assets/168567887/b7d4ddb5-2490-483e-827f-fc580167cae0)
