### PR TITLE
Dummy lines in WRITER's method create_xl_sheet should not create 'C' node without cell coords

### DIFF
--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -4343,9 +4343,9 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
            ls_sheet_content-cell_value = lc_dummy_cell_content.
 *Check if empty row is really necessary - this is basically the case when we have information in row_dimension
           lo_row_empty = io_worksheet->get_row( lv_current_row ).
-          CHECK lo_row_empty->get_row_height( )                 >= 0         OR
-                lo_row_empty->get_collapsed( io_worksheet )      = abap_true OR
-                lo_row_empty->get_outline_level( io_worksheet )  > 0         OR
+          CHECK lo_row_empty->get_row_height( )                 >= 0          OR
+                lo_row_empty->get_collapsed( io_worksheet )      = abap_true  OR
+                lo_row_empty->get_outline_level( io_worksheet )  > 0          OR
                 lo_row_empty->get_xf_index( )                   <> 0.
         ENDIF.
         IF lv_current_row = ls_sheet_content-cell_row. " cell value found in this row
@@ -4428,7 +4428,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 
       CHECK <ls_sheet_content>-cell_value <> lc_dummy_cell_content.
 *---> According to the other dummy lines from the WHILE loop above the start and end lines
-*     contain dummy content only in column A without cell_coords, which don't need a 'C' node.
+*     contain dummy content without cell_coords in column A only, which don't need a 'C' node.
 
       lo_element_3 = io_document->create_simple_element( name   = lc_xml_node_c
                                                          parent = io_document ).

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -4339,10 +4339,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
       WHILE lv_next_row <= ls_sheet_content-cell_row.
         lv_current_row = lv_next_row.
         lv_next_row = lv_current_row + 1.
-        IF lv_current_row = ls_sheet_content-cell_row. " cell value found in this row
-          ASSIGN ls_sheet_content TO <ls_sheet_content>.
-        ENDIF.
-        IF lv_current_row <> ls_sheet_content-cell_row OR " greater doesn't occur here
+        IF lv_current_row <> ls_sheet_content-cell_row OR " if true it is always less here
            ls_sheet_content-cell_value = lc_dummy_cell_content.
 *Check if empty row is really necessary - this is basically the case when we have information in row_dimension
           lo_row_empty = io_worksheet->get_row( lv_current_row ).
@@ -4351,7 +4348,9 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
                 lo_row_empty->get_outline_level( io_worksheet )  > 0          OR
                 lo_row_empty->get_xf_index( )                   <> 0.
         ENDIF.
-        IF lv_current_row <> ls_sheet_content-cell_row. " greater doesn't occur here
+        IF lv_current_row = ls_sheet_content-cell_row. " cell value found in this row
+          ASSIGN ls_sheet_content TO <ls_sheet_content>.
+        ELSE.
           " Dummyentry in column A
           ls_sheet_content_empty-cell_row      = lv_current_row.
           ls_sheet_content_empty-cell_column   = 1.
@@ -4427,7 +4426,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
         ls_last_row = <ls_sheet_content>.
       ENDWHILE.
 
-      CHECK <ls_sheet_content>-cell_value <> lc_dummy_cell_content.
+      CHECK ls_sheet_content-cell_value <> lc_dummy_cell_content.
 *---> According to the other dummy lines from the WHILE loop above the start and end lines
 *     contain dummy content without cell_coords in column A only, which don't need a 'C' node.
 

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -4339,7 +4339,10 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
       WHILE lv_next_row <= ls_sheet_content-cell_row.
         lv_current_row = lv_next_row.
         lv_next_row = lv_current_row + 1.
-        IF lv_current_row <> ls_sheet_content-cell_row OR
+        IF lv_current_row = ls_sheet_content-cell_row. " cell value found in this row
+          ASSIGN ls_sheet_content TO <ls_sheet_content>.
+        ENDIF.
+        IF lv_current_row <> ls_sheet_content-cell_row OR " greater doesn't occur here
            ls_sheet_content-cell_value = lc_dummy_cell_content.
 *Check if empty row is really necessary - this is basically the case when we have information in row_dimension
           lo_row_empty = io_worksheet->get_row( lv_current_row ).
@@ -4348,9 +4351,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
                 lo_row_empty->get_outline_level( io_worksheet )  > 0          OR
                 lo_row_empty->get_xf_index( )                   <> 0.
         ENDIF.
-        IF lv_current_row = ls_sheet_content-cell_row. " cell value found in this row
-          ASSIGN ls_sheet_content TO <ls_sheet_content>.
-        ELSE.
+        IF lv_current_row <> ls_sheet_content-cell_row. " greater doesn't occur here
           " Dummyentry in column A
           ls_sheet_content_empty-cell_row      = lv_current_row.
           ls_sheet_content_empty-cell_column   = 1.

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -4534,7 +4534,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 
       lo_element_2->append_child( new_child = lo_element_3 ). " column node
     ENDLOOP.
-    IF sy-subrc = 0.
+    IF sy-subrc = 0 AND ls_last_row-cell_row IS NOT INITIAL.
       READ TABLE lt_values INTO ls_values WITH KEY column = ls_last_row-cell_column.
       IF sy-subrc = 0 AND ls_values-value = ls_last_row-cell_value.
         CLEAR l_autofilter_hidden.


### PR DESCRIPTION
Hallo,

solves #1081.

You know: The aim of using dummy lines in this code is to avoid omitting any row class data.

There are two kinds of dummy lines.
The start and end lines containing the dummy cell content and the lines created in the WHILE Loop.
Solution:
The start and end lines must be handled more exactly like the other dummy lines.

That means:
1) Their row data class must be checked for relevant values, too. That's why the existing CHECK now gets its own surrounding IF.
2) And they get no 'C' node in the 'ROW' node, too That's why i included a new CHECK before creating this node.
   For explanation: The other dummy lines create ROW data in the WHILE loop an cannot get to this point.

Note: It is intended to use ls_sheet_content in the new CHECK line. If continuing the loop at this point the field symbol <ls_sheet_content> may be not or wrong assigned.

Furthermore i would prefer renaming <ls_sheet_content> to ls_sheet_content from this point down to the ENDLOOP.
The usage of the field-symbol is not caused by any relation to the WHILE loop but because the LOOP starts in the early days of ABAP2XLSX with ASSIGNING TO <ls_sheet_content>. But now INTO ls_sheet_content is used.
To avoid confusion this is not included yet.