### PR TITLE
How to get rid of the obscure code in writer's method create_xl_sheet_sheet_data step #1

### DIFF
--- a/src/zcl_excel_autofilter.clas.abap
+++ b/src/zcl_excel_autofilter.clas.abap
@@ -19,7 +19,7 @@ CLASS zcl_excel_autofilter DEFINITION
         tr_textfilter2   TYPE RANGE OF string,
       END OF ts_filter .
     TYPES:
-      tt_filters TYPE HASHED TABLE OF ts_filter WITH UNIQUE KEY column .
+      tt_filters TYPE SORTED TABLE OF ts_filter WITH UNIQUE KEY column .
 
     DATA filter_area TYPE zexcel_s_autofilter_area .
     CONSTANTS mc_filter_rule_single_values TYPE tv_filter_rule VALUE 'single_values'. "#EC NOTEXT
@@ -208,9 +208,6 @@ CLASS zcl_excel_autofilter IMPLEMENTATION.
   METHOD is_row_hidden.
 
 
-    DATA: lr_filter TYPE REF TO ts_filter,
-          lv_col    TYPE i.
-
     FIELD-SYMBOLS: <ls_filter> TYPE ts_filter.
 
     rv_is_hidden = abap_false.
@@ -219,29 +216,25 @@ CLASS zcl_excel_autofilter IMPLEMENTATION.
 * 1st row of filter area is never hidden, because here the filter
 * symbol is being shown
 *--------------------------------------------------------------------*
-    IF iv_row = me->filter_area-row_start.
+    IF iv_row <= me->filter_area-row_start OR
+       iv_row >  me->filter_area-row_end.
       RETURN.
     ENDIF.
 
 
-    lv_col = me->filter_area-col_start.
-
-
-    WHILE lv_col <= me->filter_area-col_end.
-
-      lr_filter = me->get_column_filter( lv_col ).
-      ASSIGN lr_filter->* TO <ls_filter>.
+    LOOP AT mt_filters ASSIGNING <ls_filter> WHERE column >= me->filter_area-col_start
+                                               AND column <= me->filter_area-col_end.
 
       CASE <ls_filter>-rule.
 
         WHEN mc_filter_rule_single_values.
           rv_is_hidden = me->is_row_hidden_single_values( iv_row    = iv_row
-                                                          iv_col    = lv_col
+                                                          iv_col    = <ls_filter>-column
                                                           is_filter = <ls_filter> ).
 
         WHEN mc_filter_rule_text_pattern.
           rv_is_hidden = me->is_row_hidden_text_pattern(  iv_row    = iv_row
-                                                          iv_col    = lv_col
+                                                          iv_col    = <ls_filter>-column
                                                           is_filter = <ls_filter> ).
 
       ENDCASE.
@@ -250,10 +243,7 @@ CLASS zcl_excel_autofilter IMPLEMENTATION.
         RETURN.
       ENDIF.
 
-
-      ADD 1 TO lv_col.
-
-    ENDWHILE.
+    ENDLOOP.
 
 
   ENDMETHOD.

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -4396,7 +4396,8 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
           IF ls_last_row-cell_row IS NOT INITIAL.
             " Row visibility of previos row.
             IF lo_row->get_visible( io_worksheet ) = abap_false OR
-               l_autofilter_hidden = abap_true.
+               ( lo_autofilter IS BOUND AND
+                 lo_autofilter->is_row_hidden( ls_last_row-cell_row ) = abap_true ).
               lo_element_2->set_attribute_ns( name  = 'hidden' value = 'true' ).
             ENDIF.
             rv_ixml_sheet_data_root->append_child( new_child = lo_element_2 ). " row node
@@ -4575,7 +4576,8 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
       ENDIF.
       " Row visibility of previos row.
       IF lo_row->get_visible( ) = abap_false OR
-         l_autofilter_hidden = abap_true.
+         ( lo_autofilter IS BOUND AND
+           lo_autofilter->is_row_hidden( ls_last_row-cell_row ) = abap_true ).
         lo_element_2->set_attribute_ns( name  = 'hidden' value = 'true' ).
       ENDIF.
       rv_ixml_sheet_data_root->append_child( new_child = lo_element_2 ). " row node

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -4233,9 +4233,6 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
     DATA: col_count              TYPE int4,
           lo_autofilters         TYPE REF TO zcl_excel_autofilters,
           lo_autofilter          TYPE REF TO zcl_excel_autofilter,
-          l_autofilter_hidden    TYPE flag,
-          lt_values              TYPE zexcel_t_autofilter_values,
-          ls_values              TYPE zexcel_s_autofilter_values,
           ls_area                TYPE zexcel_s_autofilter_area,
 
           lo_iterator            TYPE REF TO zcl_excel_collection_iterator,
@@ -4282,9 +4279,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
     lo_autofilters = excel->get_autofilters_reference( ).
     lo_autofilter  = lo_autofilters->get( io_worksheet = io_worksheet ) .
     IF lo_autofilter IS BOUND.
-      lt_values           = lo_autofilter->get_values( ) .
       ls_area             = lo_autofilter->get_filter_area( ) .
-      l_autofilter_hidden = abap_true. " First defautl is not showing
     ENDIF.
 *--------------------------------------------------------------------*
 *issue #220 - If cell in tables-area don't use default from row or column or sheet - Coding 1 - start
@@ -4347,14 +4342,6 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 
     CLEAR ls_sheet_content.
     LOOP AT io_worksheet->sheet_content INTO ls_sheet_content.
-      IF lt_values IS INITIAL. " no values attached to autofilter  " issue #368 autofilter filtering too much
-        CLEAR l_autofilter_hidden.
-      ELSE.
-        READ TABLE lt_values INTO ls_values WITH KEY column = ls_last_row-cell_column.
-        IF sy-subrc = 0 AND ls_values-value = ls_last_row-cell_value.
-          CLEAR l_autofilter_hidden.
-        ENDIF.
-      ENDIF.
       CLEAR ls_style_mapping.
 *Create row element
 *issues #346,#154, #195  - problems when we have information in row_dimension but no cell content in that row
@@ -4385,14 +4372,6 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
         ENDIF.
 
         IF ls_last_row-cell_row NE <ls_sheet_content>-cell_row.
-          IF lo_autofilter IS BOUND.
-            IF ls_area-row_start >=  ls_last_row-cell_row OR " One less for header
-              ls_area-row_end   < ls_last_row-cell_row .
-              CLEAR l_autofilter_hidden.
-            ENDIF.
-          ELSE.
-            CLEAR l_autofilter_hidden.
-          ENDIF.
           IF ls_last_row-cell_row IS NOT INITIAL.
             " Row visibility of previos row.
             IF lo_row->get_visible( io_worksheet ) = abap_false OR
@@ -4444,11 +4423,6 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
             lv_value = lo_row->get_xf_index( ).
             lo_element_2->set_attribute_ns( name  = 's' value = lv_value ).
             lo_element_2->set_attribute_ns( name  = 'customFormat'  value = '1' ).
-          ENDIF.
-          IF lt_values IS INITIAL. " no values attached to autofilter  " issue #368 autofilter filtering too much
-            CLEAR l_autofilter_hidden.
-          ELSE.
-            l_autofilter_hidden = abap_true. " First default is not showing
           ENDIF.
         ELSE.
 
@@ -4562,18 +4536,6 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
       ls_last_row = <ls_sheet_content>.
     ENDLOOP.
     IF sy-subrc = 0.
-      READ TABLE lt_values INTO ls_values WITH KEY column = ls_last_row-cell_column.
-      IF sy-subrc = 0 AND ls_values-value = ls_last_row-cell_value.
-        CLEAR l_autofilter_hidden.
-      ENDIF.
-      IF lo_autofilter IS BOUND.
-        IF ls_area-row_start >=  ls_last_row-cell_row OR " One less for header
-          ls_area-row_end   < ls_last_row-cell_row .
-          CLEAR l_autofilter_hidden.
-        ENDIF.
-      ELSE.
-        CLEAR l_autofilter_hidden.
-      ENDIF.
       " Row visibility of previos row.
       IF lo_row->get_visible( ) = abap_false OR
          ( lo_autofilter IS BOUND AND

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -4233,7 +4233,6 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
     DATA: col_count              TYPE int4,
           lo_autofilters         TYPE REF TO zcl_excel_autofilters,
           lo_autofilter          TYPE REF TO zcl_excel_autofilter,
-          ls_area                TYPE zexcel_s_autofilter_area,
 
           lo_iterator            TYPE REF TO zcl_excel_collection_iterator,
           lo_table               TYPE REF TO zcl_excel_table,
@@ -4279,7 +4278,8 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
     lo_autofilters = excel->get_autofilters_reference( ).
     lo_autofilter  = lo_autofilters->get( io_worksheet = io_worksheet ) .
     IF lo_autofilter IS BOUND.
-      ls_area             = lo_autofilter->get_filter_area( ) .
+*     Area not used here, but makes the validation for lo_autofilter->is_row_hidden
+      lo_autofilter->get_filter_area( ) .
     ENDIF.
 *--------------------------------------------------------------------*
 *issue #220 - If cell in tables-area don't use default from row or column or sheet - Coding 1 - start


### PR DESCRIPTION
closes #440 and is the first step of #1230 (not yet closed)

As described in discussions #1229 the current autofilter finds only the first value of each filter column (1st bug)
and then shows the line independent from all other filter columns (2nd bug).

This is the demo program (similar to ZDEMO_EXCEL33) containing data for 4 clients and
an autofilter for clients 001 and 002 and country BE and DE in that order.

```abap
REPORT  zdemo_excel33_test.

TYPES: BEGIN OF ty_t005t_line,
         mandt   TYPE mandt,
         spras   TYPE spras,
         land1   TYPE land1,
         landx   TYPE landx,
         natio   TYPE natio,
         landx50 TYPE landx50,
         natio50 TYPE natio50,
       END OF ty_t005t_line,
       ty_t005t_lines TYPE TABLE OF ty_t005t_line.

DATA: lo_excel      TYPE REF TO zcl_excel,
      lo_worksheet  TYPE REF TO zcl_excel_worksheet,
      lo_converter  TYPE REF TO zcl_excel_converter,
      lo_autofilter TYPE REF TO zcl_excel_autofilter.

DATA lt_test TYPE ty_t005t_lines.

DATA: l_cell_value TYPE zexcel_cell_value,
      ls_area      TYPE zexcel_s_autofilter_area.
DATA: ls_option TYPE zexcel_s_converter_option.

CONSTANTS: gc_save_file_name TYPE string VALUE '33_autofilter.xlsx'.
INCLUDE zdemo_excel_outputopt_incl.

PARAMETERS p_convex AS CHECKBOX.

START-OF-SELECTION.

  " Creates active sheet
  CREATE OBJECT lo_excel.

  " Get active sheet
  lo_worksheet = lo_excel->get_active_worksheet( ).
  lo_worksheet->set_title( ip_title = 'Internal table' ).

  PERFORM load_fixed_data CHANGING lt_test.

  CREATE OBJECT lo_converter.

  ls_option-conv_exit_length = p_convex.
* lo_converter->set_option( ls_option ).
  lo_converter->convert( EXPORTING
                            is_option    = ls_option    "use ls_option here
                            it_table     = lt_test
                            i_row_int    = 1
                            i_column_int = 1
                            io_worksheet = lo_worksheet
                         CHANGING
                            co_excel     = lo_excel ) .
  PERFORM set_column_headers USING lo_worksheet 'Client;Language;Country;Name;Nationality;Long name;Nationality'.

  lo_autofilter = lo_excel->add_new_autofilter( io_sheet = lo_worksheet ) .

  ls_area-row_start = 1.
  ls_area-col_start = 1.
  ls_area-row_end = lo_worksheet->get_highest_row( ).
  ls_area-col_end = lo_worksheet->get_highest_column( ).

  lo_autofilter->set_filter_area( is_area = ls_area ).

*  lo_worksheet->get_cell( EXPORTING
*                             ip_column    = 'C'
*                             ip_row       = 2
*                          IMPORTING
*                             ep_value     = l_cell_value ).
*  lo_autofilter->set_value( i_column = 3
*                            i_value  = l_cell_value ).
  lo_autofilter->set_value( i_column = 1
                            i_value  = '001' ).
  lo_autofilter->set_value( i_column = 1
                            i_value  = '002' ).
  lo_autofilter->set_value( i_column = 3
                            i_value  = 'BE' ).
  lo_autofilter->set_value( i_column = 3
                            i_value  = 'DE' ).


*** Create output
  lcl_output=>output( lo_excel ).


*&---------------------------------------------------------------------*
*&      Form  load_fixed_data
*&---------------------------------------------------------------------*
*       text
*----------------------------------------------------------------------*
*      -->CT_TEST    text
*----------------------------------------------------------------------*
FORM load_fixed_data CHANGING ct_test TYPE ty_t005t_lines.
  DATA: lt_lines  TYPE TABLE OF string,
        lv_line   TYPE string,
        lt_fields TYPE TABLE OF string,
        lv_comp   TYPE i,
        lv_field  TYPE string,
        ls_test   TYPE t005t.
  FIELD-SYMBOLS: <lv_field> TYPE simple.

  APPEND '001 E AD Andorra    Andorran    Andorra    Andorran   ' TO lt_lines.
  APPEND '001 E BE Belgium    Belgian     Belgium    Belgian    ' TO lt_lines.
  APPEND '001 E DE Germany    German      Germany    German     ' TO lt_lines.
  APPEND '001 E FM Micronesia Micronesian Micronesia Micronesian' TO lt_lines.
  APPEND '002 E AD Andorra    Andorran    Andorra    Andorran   ' TO lt_lines.
  APPEND '002 E BE Belgium    Belgian     Belgium    Belgian    ' TO lt_lines.
  APPEND '002 E DE Germany    German      Germany    German     ' TO lt_lines.
  APPEND '002 E FM Micronesia Micronesian Micronesia Micronesian' TO lt_lines.
  APPEND '003 E AD Andorra    Andorran    Andorra    Andorran   ' TO lt_lines.
  APPEND '003 E BE Belgium    Belgian     Belgium    Belgian    ' TO lt_lines.
  APPEND '003 E DE Germany    German      Germany    German     ' TO lt_lines.
  APPEND '003 E FM Micronesia Micronesian Micronesia Micronesian' TO lt_lines.
  APPEND '004 E AD Andorra    Andorran    Andorra    Andorran   ' TO lt_lines.
  APPEND '004 E BE Belgium    Belgian     Belgium    Belgian    ' TO lt_lines.
  APPEND '004 E DE Germany    German      Germany    German     ' TO lt_lines.
  APPEND '004 E FM Micronesia Micronesian Micronesia Micronesian' TO lt_lines.
  LOOP AT lt_lines INTO lv_line.
    CONDENSE lv_line.
    SPLIT lv_line AT space INTO TABLE lt_fields.
    lv_comp = 1.
    LOOP AT lt_fields INTO lv_field.
      ASSIGN COMPONENT lv_comp OF STRUCTURE ls_test TO <lv_field>.
      <lv_field> = lv_field.
      lv_comp = lv_comp + 1.
    ENDLOOP.
    APPEND ls_test TO ct_test.
  ENDLOOP.
ENDFORM.                    "load_fixed_data

*&---------------------------------------------------------------------*
*&      Form  set_column_headers
*&---------------------------------------------------------------------*
*       text
*----------------------------------------------------------------------*
*      -->IO_WORKSHEET  text
*      -->IV_HEADERS    text
*      -->RAISING       text
*      -->ZCX_EXCEL     text
*----------------------------------------------------------------------*
FORM set_column_headers
    USING io_worksheet TYPE REF TO zcl_excel_worksheet
          iv_headers   TYPE csequence
    RAISING zcx_excel.

  DATA: lt_headers TYPE TABLE OF string,
        lv_header  TYPE string,
        lv_tabix   TYPE i.

  SPLIT iv_headers AT ';' INTO TABLE lt_headers.
  LOOP AT lt_headers INTO lv_header.
    lv_tabix = sy-tabix.
    io_worksheet->set_cell( ip_row = 1 ip_column = lv_tabix ip_value = lv_header ).
  ENDLOOP.

ENDFORM.                    "set_column_headers
```

The following attachment contains the wrong result:
Lines 2-5 are shown because of 001 (first value for client) independent from filter values for country.
Lines 3,7,11,15 are shown because of BE (first value for country) independent from filter values for client.
Line 3 is a mix of both.
[33_autofilter_wrong.xlsx](https://github.com/abap2xlsx/abap2xlsx/files/15469001/33_autofilter_wrong.xlsx)

And this is the result after the fix:
[33_autofilter_ok.xlsx](https://github.com/abap2xlsx/abap2xlsx/files/15469011/33_autofilter_ok.xlsx)
