### PR TITLE
Options to skip hidden rows and columns for CSV format

### DIFF
--- a/src/zcl_excel_writer_csv.clas.abap
+++ b/src/zcl_excel_writer_csv.clas.abap
@@ -125,6 +125,7 @@ CLASS ZCL_EXCEL_WRITER_CSV IMPLEMENTATION.
     SELECT ddtext INTO ls_format-attvalue FROM dd07t WHERE domname    = 'XUDATFM'
                                                        AND ( ddlanguage = sy-langu OR ddlanguage = 'E' ).
       ls_format-cmpname = 'DATE'.
+      ls_format-attvalue = ls_format-attvalue(10). " Ignore description, only use pattern
       CONDENSE ls_format-attvalue.
       CONCATENATE '''' ls_format-attvalue '''' INTO ls_format-attvalue.
       APPEND ls_format TO lt_format.

--- a/src/zcl_excel_writer_csv.clas.abap
+++ b/src/zcl_excel_writer_csv.clas.abap
@@ -165,6 +165,9 @@ CLASS ZCL_EXCEL_WRITER_CSV IMPLEMENTATION.
     IF skip_hidden_rows = abap_true.
 * --- Retrieve autofilters (to identify hidden rows)
       lo_autofilter = excel->get_autofilters_reference( )->get( io_worksheet = lo_worksheet ).
+      IF lo_autofilter IS NOT INITIAL.
+        lo_autofilter->get_filter_area( ). " trigger filter area validation
+      ENDIF.
     ENDIF.
 
     lv_row = 1.

--- a/src/zcl_excel_writer_csv.clas.abap
+++ b/src/zcl_excel_writer_csv.clas.abap
@@ -31,10 +31,10 @@ CLASS zcl_excel_writer_csv DEFINITION
       IMPORTING
         !ip_value TYPE char10 DEFAULT c_default .
     CLASS-METHODS set_skip_hidden_rows
-      IMPORTING 
+      IMPORTING
         !ip_value TYPE abap_bool.
     CLASS-METHODS set_skip_hidden_columns
-      IMPORTING 
+      IMPORTING
         !ip_value TYPE abap_bool.
 *"* protected components of class ZCL_EXCEL_WRITER_CSV
 *"* do not include other source files here!!!
@@ -98,6 +98,8 @@ CLASS ZCL_EXCEL_WRITER_CSV IMPLEMENTATION.
 
     DATA: lo_iterator  TYPE REF TO zcl_excel_collection_iterator,
           lo_worksheet TYPE REF TO zcl_excel_worksheet.
+
+    DATA: lo_autofilter TYPE REF TO zcl_excel_autofilter.
 
     DATA: lt_cell_data TYPE zexcel_t_cell_data_unsorted,
           lv_row       TYPE i,

--- a/src/zcl_excel_writer_csv.clas.abap
+++ b/src/zcl_excel_writer_csv.clas.abap
@@ -123,7 +123,7 @@ CLASS ZCL_EXCEL_WRITER_CSV IMPLEMENTATION.
 * --- Retrieve SAP date format
     CLEAR ls_format.
     SELECT ddtext INTO ls_format-attvalue FROM dd07t WHERE domname    = 'XUDATFM'
-                                                       AND ddlanguage = sy-langu.
+                                                       AND ( ddlanguage = sy-langu OR ddlanguage = 'E' ).
       ls_format-cmpname = 'DATE'.
       CONDENSE ls_format-attvalue.
       CONCATENATE '''' ls_format-attvalue '''' INTO ls_format-attvalue.

--- a/src/zcl_excel_writer_csv.clas.abap
+++ b/src/zcl_excel_writer_csv.clas.abap
@@ -100,6 +100,7 @@ CLASS ZCL_EXCEL_WRITER_CSV IMPLEMENTATION.
           lo_worksheet TYPE REF TO zcl_excel_worksheet.
 
     DATA: lo_autofilter TYPE REF TO zcl_excel_autofilter.
+    DATA: lv_row_hidden TYPE abap_bool.
 
     DATA: lt_cell_data TYPE zexcel_t_cell_data_unsorted,
           lv_row       TYPE i,
@@ -176,6 +177,13 @@ CLASS ZCL_EXCEL_WRITER_CSV IMPLEMENTATION.
     CLEAR lv_string.
     LOOP AT lt_cell_data ASSIGNING <fs_sheet_content>.
 
+* --- Check, if row is hidden
+      AT NEW cell_row.
+        IF lo_autofilter IS NOT INITIAL.
+          lv_row_hidden = lo_autofilter->is_row_hidden( iv_row = <fs_sheet_content>-cell_row ).
+        ENDIF.
+      ENDAT.
+
 * --- Add empty rows
       WHILE lv_row < <fs_sheet_content>-cell_row.
         CONCATENATE lv_string zcl_excel_writer_csv=>eol INTO lv_string.
@@ -184,9 +192,7 @@ CLASS ZCL_EXCEL_WRITER_CSV IMPLEMENTATION.
       ENDWHILE.
 
 * --- Skip hidden rows
-      IF skip_hidden_rows = abap_true AND
-          lo_autofilter IS NOT INITIAL AND
-          lo_autofilter->is_row_hidden( iv_row = <fs_sheet_content>-cell_row ) = abap_true.
+      IF lv_row_hidden = abap_true.
         lv_row = <fs_sheet_content>-cell_row + 1.
         lv_col = 1.
         CONTINUE.


### PR DESCRIPTION
Add options to skip hidden rows and columns when saving the data in CSV format. This is especially useful, when converting an ALV to an Excel object and saving it as CSV file. ALV layouts often display only selected columns.