### PR TITLE
use APLHA for cols in reference string

### DIFF
--- a/src/zcl_excel_table.clas.abap
+++ b/src/zcl_excel_table.clas.abap
@@ -174,8 +174,10 @@ CLASS zcl_excel_table IMPLEMENTATION.
 
 
   METHOD get_reference.
-    DATA: lv_column                TYPE zexcel_cell_column,
+    DATA: lv_start_column          TYPE zexcel_cell_column,
+          lv_end_column            TYPE zexcel_cell_column,
           lv_table_lines           TYPE i,
+          lv_left_column           TYPE zexcel_cell_column_alpha,
           lv_right_column          TYPE zexcel_cell_column_alpha,
           ls_field_catalog         TYPE zexcel_s_fieldcatalog,
           lv_bottom_row            TYPE zexcel_cell_row,
@@ -185,13 +187,12 @@ CLASS zcl_excel_table IMPLEMENTATION.
     FIELD-SYMBOLS: <fs_table> TYPE STANDARD TABLE.
 
 *column
-    lv_column = zcl_excel_common=>convert_column2int( settings-top_left_column ).
+    lv_start_column = zcl_excel_common=>convert_column2int( settings-top_left_column ).
     lv_table_lines = 0.
     LOOP AT fieldcat INTO ls_field_catalog WHERE dynpfld EQ abap_true.
       ADD 1 TO lv_table_lines.
     ENDLOOP.
-    lv_column = lv_column + lv_table_lines - 1.
-    lv_right_column  = zcl_excel_common=>convert_column2alpha( lv_column ).
+    lv_end_column = lv_start_column + lv_table_lines - 1.
 
 *row
     ASSIGN table_data->* TO <fs_table>.
@@ -208,7 +209,9 @@ CLASS zcl_excel_table IMPLEMENTATION.
     lv_top_row_string = zcl_excel_common=>number_to_excel_string( settings-top_left_row ).
     lv_bottom_row_string = zcl_excel_common=>number_to_excel_string( lv_bottom_row ).
 
-    CONCATENATE settings-top_left_column lv_top_row_string
+    lv_left_column  = zcl_excel_common=>convert_column2alpha( lv_start_column ).
+    lv_right_column  = zcl_excel_common=>convert_column2alpha( lv_end_column ).
+    CONCATENATE lv_left_column lv_top_row_string
                 ':'
                 lv_right_column lv_bottom_row_string INTO ov_reference.
 


### PR DESCRIPTION
fixes #1215

bind table works with 'A' or 1 for top_left_column now 
```
 lo_worksheet->bind_table(
      ip_table            = t006_lines
      is_table_settings   = VALUE #( top_left_column = <3 | 'C'>
                                     top_left_row    = 1 ) ).
```