### PR TITLE
replace use of `TDCWIDTHS` with `I`

### DIFF
--- a/abap_transpile.json
+++ b/abap_transpile.json
@@ -56,7 +56,6 @@
       {"object": "ZCL_EXCEL_READER_HUGE_FILE", "class": "lcl_test", "method": "test_shared_string_multi_style", "note": "??"},
       {"object": "ZCL_EXCEL_READER_HUGE_FILE", "class": "lcl_test", "method": "test_skip_to_inexistent",        "note": "??"},
 
-      {"object": "ZCL_EXCEL_WRITER_2007", "class": "ltc_column_formula", "method": "one_column_formula",        "note": "?? CALL TRANSFORMATION xml_header = 'no'"},
       {"object": "ZCL_EXCEL_WRITER_2007", "class": "ltc_column_formula", "method": "two_column_formulas",       "note": "??"},
 
       {"object": "ZCL_EXCEL_COMMON", "class": "ltc_utclong_to_excel_string", "method": "simple", "note": "?? missing method CL_ABAP_TSTMP=>UTCLONG2TSTMP_SHORT, I'm too lazy to add it today"},

--- a/abap_transpile.json
+++ b/abap_transpile.json
@@ -56,7 +56,7 @@
       {"object": "ZCL_EXCEL_READER_HUGE_FILE", "class": "lcl_test", "method": "test_shared_string_multi_style", "note": "??"},
       {"object": "ZCL_EXCEL_READER_HUGE_FILE", "class": "lcl_test", "method": "test_skip_to_inexistent",        "note": "??"},
 
-      {"object": "ZCL_EXCEL_COMMON", "class": "ltc_utclong_to_excel_string", "method": "simple", "note": "?? missing method CL_ABAP_TSTMP=>UTCLONG2TSTMP_SHORT, I'm too lazy to add it today"},
+      {"object": "ZCL_EXCEL_COMMON", "class": "ltc_utclong_to_excel_string", "method": "simple", "note": "todo CL_ABAP_TSTMP=>UTCLONG2TSTMP_SHORT"},
       {"object": "ZCL_EXCEL_COMMON", "class": "lcl_excel_common_test", "method": "convert_column2int_oob_empty", "note": "?? sy value defaults"}
     ]
   }

--- a/abap_transpile.json
+++ b/abap_transpile.json
@@ -5,7 +5,7 @@
     "src/zcl_excel_c",
     "src/zcl_excel_d",
     "src/zcl_excel_fill_template",
-    "src/zcl_excel_font TODO, missing TDFONTSIZE",
+    "src/zcl_excel_font",
     "src/zcl_excel_g",
     "src/zcl_excel_h",
     "src/zcl_excel_l",
@@ -55,6 +55,8 @@
       {"object": "ZCL_EXCEL_READER_HUGE_FILE", "class": "lcl_test", "method": "test_shared_string_some_empty",  "note": "??"},
       {"object": "ZCL_EXCEL_READER_HUGE_FILE", "class": "lcl_test", "method": "test_shared_string_multi_style", "note": "??"},
       {"object": "ZCL_EXCEL_READER_HUGE_FILE", "class": "lcl_test", "method": "test_skip_to_inexistent",        "note": "??"},
+
+      {"object": "ZCL_EXCEL_FONT", "class": "ltcl_test", "method": "calculate", "note": "Error: Void type: ITCFC, this needs to be fixed anyhow for cloud compatibility"},
 
       {"object": "ZCL_EXCEL_COMMON", "class": "ltc_utclong_to_excel_string", "method": "simple", "note": "todo CL_ABAP_TSTMP=>UTCLONG2TSTMP_SHORT"},
       {"object": "ZCL_EXCEL_COMMON", "class": "lcl_excel_common_test", "method": "convert_column2int_oob_empty", "note": "?? sy value defaults"}

--- a/abap_transpile.json
+++ b/abap_transpile.json
@@ -56,8 +56,6 @@
       {"object": "ZCL_EXCEL_READER_HUGE_FILE", "class": "lcl_test", "method": "test_shared_string_multi_style", "note": "??"},
       {"object": "ZCL_EXCEL_READER_HUGE_FILE", "class": "lcl_test", "method": "test_skip_to_inexistent",        "note": "??"},
 
-      {"object": "ZCL_EXCEL_WRITER_2007", "class": "ltc_column_formula", "method": "two_column_formulas",       "note": "??"},
-
       {"object": "ZCL_EXCEL_COMMON", "class": "ltc_utclong_to_excel_string", "method": "simple", "note": "?? missing method CL_ABAP_TSTMP=>UTCLONG2TSTMP_SHORT, I'm too lazy to add it today"},
       {"object": "ZCL_EXCEL_COMMON", "class": "lcl_excel_common_test", "method": "convert_column2int_oob_empty", "note": "?? sy value defaults"}
     ]

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "url": "git+https://github.com/abap2xlsx/abap2xlsx.git"
   },
   "devDependencies": {
-    "@abaplint/cli": "^2.113.119",
-    "@abaplint/transpiler-cli": "^2.10.55",
-    "@abaplint/runtime": "^2.10.55"
+    "@abaplint/cli": "^2.113.121",
+    "@abaplint/transpiler-cli": "^2.10.57",
+    "@abaplint/runtime": "^2.10.57"
   }
 }

--- a/src/zcl_excel_font.clas.abap
+++ b/src/zcl_excel_font.clas.abap
@@ -23,7 +23,7 @@ CLASS zcl_excel_font DEFINITION
     TYPES:
       BEGIN OF mty_s_font_metric,
         char       TYPE c LENGTH 1,
-        char_width TYPE tdcwidths,
+        char_width TYPE i,
       END OF mty_s_font_metric .
     TYPES:
       mty_th_font_metrics


### PR DESCRIPTION
for increased ABAP Cloud compatibility

plus more unit testing via open-abap