### PR TITLE
Remove code duplication in check_rtf

### DIFF
--- a/src/zcl_excel.clas.abap
+++ b/src/zcl_excel.clas.abap
@@ -22,6 +22,11 @@ CLASS zcl_excel DEFINITION
         VALUE(ro_autofilter) TYPE REF TO zcl_excel_autofilter
       RAISING
         zcx_excel .
+    METHODS get_style_from_guid
+      IMPORTING
+        !ip_guid        TYPE zexcel_cell_style
+      RETURNING
+        VALUE(eo_style) TYPE REF TO zcl_excel_style .
     METHODS add_new_comment
       RETURNING
         VALUE(eo_comment) TYPE REF TO zcl_excel_comment .
@@ -172,11 +177,6 @@ CLASS zcl_excel DEFINITION
     DATA theme TYPE REF TO zcl_excel_theme .
     DATA comments TYPE REF TO zcl_excel_comments .
 
-    METHODS get_style_from_guid
-      IMPORTING
-        !ip_guid        TYPE zexcel_cell_style
-      RETURNING
-        VALUE(eo_style) TYPE REF TO zcl_excel_style .
     METHODS stylemapping_dynamic_style
       IMPORTING
         !ip_style        TYPE REF TO zcl_excel_style

--- a/src/zcl_excel.clas.abap
+++ b/src/zcl_excel.clas.abap
@@ -22,11 +22,6 @@ CLASS zcl_excel DEFINITION
         VALUE(ro_autofilter) TYPE REF TO zcl_excel_autofilter
       RAISING
         zcx_excel .
-    METHODS get_style_from_guid
-      IMPORTING
-        !ip_guid        TYPE zexcel_cell_style
-      RETURNING
-        VALUE(eo_style) TYPE REF TO zcl_excel_style .
     METHODS add_new_comment
       RETURNING
         VALUE(eo_comment) TYPE REF TO zcl_excel_comment .
@@ -102,6 +97,11 @@ CLASS zcl_excel DEFINITION
     METHODS get_styles_iterator
       RETURNING
         VALUE(eo_iterator) TYPE REF TO zcl_excel_collection_iterator .
+    METHODS get_style_from_guid
+      IMPORTING
+        !ip_guid        TYPE zexcel_cell_style
+      RETURNING
+        VALUE(eo_style) TYPE REF TO zcl_excel_style .
     METHODS get_style_index_in_styles
       IMPORTING
         !ip_guid        TYPE zexcel_cell_style

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -1949,7 +1949,7 @@ CLASS zcl_excel_worksheet IMPLEMENTATION.
   METHOD check_rtf.
 
     DATA: lo_style           TYPE REF TO zcl_excel_style,
-          lo_iterator        TYPE REF TO zcl_excel_collection_iterator,
+          ls_font            TYPE zexcel_s_style_font,
           lv_next_rtf_offset TYPE i,
           lv_tabix           TYPE i,
           lv_value           TYPE string,
@@ -1961,14 +1961,8 @@ CLASS zcl_excel_worksheet IMPLEMENTATION.
       ip_style = excel->get_default_style( ).
     ENDIF.
 
-    lo_iterator = excel->get_styles_iterator( ).
-    WHILE lo_iterator->has_next( ) = abap_true.
-      lo_style ?= lo_iterator->get_next( ).
-      IF lo_style->get_guid( ) = ip_style.
-        EXIT.
-      ENDIF.
-      CLEAR lo_style.
-    ENDWHILE.
+    lo_style = excel->get_style_from_guid( ip_style ).
+    ls_font  = lo_style->font->get_structure( ).
 
     lv_next_rtf_offset = 0.
     LOOP AT ct_rtf ASSIGNING <rtf>.
@@ -1976,7 +1970,7 @@ CLASS zcl_excel_worksheet IMPLEMENTATION.
       IF lv_next_rtf_offset < <rtf>-offset.
         ls_rtf-offset = lv_next_rtf_offset.
         ls_rtf-length = <rtf>-offset - lv_next_rtf_offset.
-        ls_rtf-font   = lo_style->font->get_structure( ).
+        ls_rtf-font   = ls_font.
         INSERT ls_rtf INTO ct_rtf INDEX lv_tabix.
       ELSEIF lv_next_rtf_offset > <rtf>-offset.
         RAISE EXCEPTION TYPE zcx_excel
@@ -1991,9 +1985,9 @@ CLASS zcl_excel_worksheet IMPLEMENTATION.
     IF lv_val_length > lv_next_rtf_offset.
       ls_rtf-offset = lv_next_rtf_offset.
       ls_rtf-length = lv_val_length - lv_next_rtf_offset.
-      ls_rtf-font   = lo_style->font->get_structure( ).
+      ls_rtf-font   = ls_font.
       INSERT ls_rtf INTO TABLE ct_rtf.
-    ELSEIF lv_val_length > lv_next_rtf_offset.
+    ELSEIF lv_val_length < lv_next_rtf_offset.
       RAISE EXCEPTION TYPE zcx_excel
         EXPORTING
           error = 'RTF specs length is not equal to value length'.


### PR DESCRIPTION
Method implementation of `zcl_excel->get_style_from_guid` is duplicated in `zcl_excel_worksheet->check_rtf`. 
This correction
- makes `zcl_excel->get_style_from_guid` public so that it can be called by `zcl_excel_worksheet `and other objects
- replaces the duplicate code in `zcl_excel_worksheet->check_rtf` by method call
- replaces multiple calls of `lo_style->font->get_structure( )` by a single call at the beginning
- repairs a bug in `zcl_excel_worksheet->check_rtf`, line 42: operator should be **<**, not **>**