### PR TITLE
Move copy code into copy constructor

### DIFF
--- a/src/zcl_excel_comments.clas.abap
+++ b/src/zcl_excel_comments.clas.abap
@@ -12,7 +12,9 @@ CLASS zcl_excel_comments DEFINITION
       IMPORTING
         !ip_comment TYPE REF TO zcl_excel_comment .
     METHODS clear .
-    METHODS constructor .
+    METHODS constructor
+      IMPORTING
+        !io_from TYPE REF TO zcl_excel_comments OPTIONAL .
     METHODS get
       IMPORTING
         !ip_index         TYPE zexcel_active_worksheet
@@ -57,7 +59,23 @@ CLASS zcl_excel_comments IMPLEMENTATION.
 
 
   METHOD constructor.
+
+    DATA: lo_comment  TYPE REF TO zcl_excel_comment,
+          lo_iterator TYPE REF TO zcl_excel_collection_iterator.
+
     CREATE OBJECT comments.
+
+    IF io_from IS BOUND.
+* Copy constructor: create new instance with copy of attributes from io_from
+* Copy all attributes of io_from to the new instance
+
+* The receiver may change the collection without affecting the original
+      lo_iterator = io_from->comments->get_iterator( ).
+      WHILE lo_iterator->has_next( ) = abap_true.
+        lo_comment ?= lo_iterator->get_next( ).
+        include( lo_comment ).
+      ENDWHILE.
+    ENDIF.
 
   ENDMETHOD.
 

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -2609,10 +2609,7 @@ CLASS zcl_excel_worksheet IMPLEMENTATION.
 
   METHOD get_comments.
 
-* Create a copy of the comments attribute
-    CREATE OBJECT r_comments
-      EXPORTING
-        io_from = comments.
+    r_comments = comments.
 
   ENDMETHOD.                    "get_comments
 

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -396,8 +396,6 @@ CLASS zcl_excel_worksheet DEFINITION
         VALUE(ep_dimension_range) TYPE string
       RAISING
         zcx_excel .
-    "! <p class="shorttext synchronized" lang="en">Get the comments instance</p>
-    "! @parameter r_comments | <p class="shorttext synchronized" lang="en">Comments instance of this worksheet</p>
     METHODS get_comments
       RETURNING
         VALUE(r_comments) TYPE REF TO zcl_excel_comments .

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -396,8 +396,8 @@ CLASS zcl_excel_worksheet DEFINITION
         VALUE(ep_dimension_range) TYPE string
       RAISING
         zcx_excel .
-    "! <p class="shorttext synchronized" lang="en">Get a copy of the comments instance</p>
-    "! @parameter r_comments | <p class="shorttext synchronized" lang="en">Copied comments instance</p>
+    "! <p class="shorttext synchronized" lang="en">Get the comments instance</p>
+    "! @parameter r_comments | <p class="shorttext synchronized" lang="en">Comments instance of this worksheet</p>
     METHODS get_comments
       RETURNING
         VALUE(r_comments) TYPE REF TO zcl_excel_comments .

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -397,6 +397,8 @@ CLASS zcl_excel_worksheet DEFINITION
       RAISING
         zcx_excel .
     METHODS get_comments
+      IMPORTING
+        iv_copy_collection TYPE flag DEFAULT abap_true
       RETURNING
         VALUE(r_comments) TYPE REF TO zcl_excel_comments .
     METHODS get_drawings
@@ -2609,7 +2611,14 @@ CLASS zcl_excel_worksheet IMPLEMENTATION.
 
   METHOD get_comments.
 
-    r_comments = comments.
+    IF iv_copy_collection = abap_true.
+* By default, get_comments copies the collection (backward compatibility)
+      CREATE OBJECT r_comments
+        EXPORTING
+          io_from = comments.
+    ELSE.
+      r_comments = comments.
+    ENDIF.
 
   ENDMETHOD.                    "get_comments
 

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -396,6 +396,8 @@ CLASS zcl_excel_worksheet DEFINITION
         VALUE(ep_dimension_range) TYPE string
       RAISING
         zcx_excel .
+    "! <p class="shorttext synchronized" lang="en">Get a copy of the comments instance</p>
+    "! @parameter r_comments | <p class="shorttext synchronized" lang="en">Copied comments instance</p>
     METHODS get_comments
       RETURNING
         VALUE(r_comments) TYPE REF TO zcl_excel_comments .
@@ -2606,16 +2608,11 @@ CLASS zcl_excel_worksheet IMPLEMENTATION.
 
 
   METHOD get_comments.
-    DATA: lo_comment  TYPE REF TO zcl_excel_comment,
-          lo_iterator TYPE REF TO zcl_excel_collection_iterator.
 
-    CREATE OBJECT r_comments.
-
-    lo_iterator = comments->get_iterator( ).
-    WHILE lo_iterator->has_next( ) = abap_true.
-      lo_comment ?= lo_iterator->get_next( ).
-      r_comments->include( lo_comment ).
-    ENDWHILE.
+* Create a copy of the comments attribute
+    CREATE OBJECT r_comments
+      EXPORTING
+        io_from = comments.
 
   ENDMETHOD.                    "get_comments
 

--- a/src/zcl_excel_worksheet.clas.xml
+++ b/src/zcl_excel_worksheet.clas.xml
@@ -246,7 +246,7 @@
     <SEOCOMPOTX>
      <CMPNAME>GET_COMMENTS</CMPNAME>
      <LANGU>E</LANGU>
-     <DESCRIPT>Get a copy of the comments instance</DESCRIPT>
+     <DESCRIPT>Get the comments instance</DESCRIPT>
     </SEOCOMPOTX>
     <SEOCOMPOTX>
      <CMPNAME>GET_DATA_VALIDATIONS_ITERATOR</CMPNAME>
@@ -614,7 +614,7 @@
      <CMPNAME>GET_COMMENTS</CMPNAME>
      <SCONAME>R_COMMENTS</SCONAME>
      <LANGU>E</LANGU>
-     <DESCRIPT>Copied comments instance</DESCRIPT>
+     <DESCRIPT>Comments instance of this worksheet</DESCRIPT>
     </SEOSUBCOTX>
    </DESCRIPTIONS_SUB>
   </asx:values>

--- a/src/zcl_excel_worksheet.clas.xml
+++ b/src/zcl_excel_worksheet.clas.xml
@@ -244,6 +244,11 @@
      <DESCRIPT>Get columns iterator</DESCRIPT>
     </SEOCOMPOTX>
     <SEOCOMPOTX>
+     <CMPNAME>GET_COMMENTS</CMPNAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Get a copy of the comments instance</DESCRIPT>
+    </SEOCOMPOTX>
+    <SEOCOMPOTX>
      <CMPNAME>GET_DATA_VALIDATIONS_ITERATOR</CMPNAME>
      <LANGU>E</LANGU>
      <DESCRIPT>Get data validation iterator</DESCRIPT>
@@ -604,6 +609,14 @@
      <DESCRIPT>Top left range cell</DESCRIPT>
     </SEOCOMPOTX>
    </DESCRIPTIONS>
+   <DESCRIPTIONS_SUB>
+    <SEOSUBCOTX>
+     <CMPNAME>GET_COMMENTS</CMPNAME>
+     <SCONAME>R_COMMENTS</SCONAME>
+     <LANGU>E</LANGU>
+     <DESCRIPT>Copied comments instance</DESCRIPT>
+    </SEOSUBCOTX>
+   </DESCRIPTIONS_SUB>
   </asx:values>
  </asx:abap>
 </abapGit>


### PR DESCRIPTION
Small refactoring: The code in `zcl_excel_worksheet->get_comments` belongs into the class `zcl_excel_comments` itself, as this latter class is the expert on handling the comment collections. Also, the method `get_comments` creates a new comments object with a collection _copied_ from the existing one, so that changes of the new collection will not affect the original. This is classically the task of a copy constructor. So the code of `zcl_excel_worksheet->get_comments` moved into the constructor of `zcl_excel_comments`.