### PR TITLE
Bug: lt_rtf uninitialized in loop in load_worksheet

### DIFF
--- a/src/zcl_excel_reader_2007.clas.abap
+++ b/src/zcl_excel_reader_2007.clas.abap
@@ -2596,7 +2596,8 @@ CLASS zcl_excel_reader_2007 IMPLEMENTATION.
       WHILE lo_ixml_cell_elem IS BOUND.
         CLEAR: lv_cell_value,
                lv_cell_formula,
-               lv_style_guid.
+               lv_style_guid,
+               lt_rtf.
 
         fill_struct_from_attributes( EXPORTING ip_element = lo_ixml_cell_elem CHANGING cp_structure = ls_cell ).
 

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -1962,7 +1962,9 @@ CLASS zcl_excel_worksheet IMPLEMENTATION.
     ENDIF.
 
     lo_style = excel->get_style_from_guid( ip_style ).
-    ls_font  = lo_style->font->get_structure( ).
+    if lo_style is bound.
+      ls_font  = lo_style->font->get_structure( ).
+    endif.
 
     lv_next_rtf_offset = 0.
     LOOP AT ct_rtf ASSIGNING <rtf>.

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -1962,9 +1962,9 @@ CLASS zcl_excel_worksheet IMPLEMENTATION.
     ENDIF.
 
     lo_style = excel->get_style_from_guid( ip_style ).
-    if lo_style is bound.
+    IF lo_style IS BOUND.
       ls_font  = lo_style->font->get_structure( ).
-    endif.
+    ENDIF.
 
     lv_next_rtf_offset = 0.
     LOOP AT ct_rtf ASSIGNING <rtf>.


### PR DESCRIPTION
The correction of PR #1315 uncovered a bug in `zcl_exel_reader_2007->load_worksheet`: while the cells are read one by one, `lt_rtf` keeps the content of the previous loop iteration (which is wrong for the next iteration). 

While formerly unintentionally ignored, this is now detected in method `check_rtf`, resulting in an exception 

> RTF specs length is not equal to value length

when reading a correct Excel sheet containing styled and unstyled cells. 

Also, in `zcl_excel_worksheet->check_rtf`, variable `lo_style` should only be used when bound. Only this `IF lo_style IS BOUND` makes the method functionally identical to the version before PR #1315  (and the case where `lo_style` is unbound at this point can occur actually).

The bug with `lt_rtf` having wrong / old content, occurs when after a cell styled with different formats, a cell without RTF data follows, as in this example: 
[rtf-bug1.xlsx](https://github.com/user-attachments/files/20789304/rtf-bug1.xlsx)
