### PR TITLE
Fix runtime error in class ZCL_EXCEL_WRITER_2007 with _X....._ pattern

### DIFF
--- a/src/zcl_excel_reader_2007.clas.abap
+++ b/src/zcl_excel_reader_2007.clas.abap
@@ -4463,7 +4463,8 @@ CLASS zcl_excel_reader_2007 IMPLEMENTATION.
   METHOD provided_string_is_escaped.
 
     "Check if passed value is really an escaped Character
-    IF value CS '_x'.
+    IF   value CS '_x'
+     AND value+sy-fdpos(2) = '_x'. " Case-sensitive check
       is_escaped = abap_true.
        TRY.
           IF substring( val = value off = sy-fdpos + 6 len = 1 ) <> '_'.


### PR DESCRIPTION
Fix https://github.com/abap2xlsx/abap2xlsx/issues/1308

Add 1 more check to make sure provided string is escaped (start with _x in lowercase)