### PR TITLE
Fix bug in method zcl_excel_common=>describe_structure: when substructure has a suffix, all field names in the structure should finish with the suffix

### DIFF
--- a/src/zcl_excel_common.clas.abap
+++ b/src/zcl_excel_common.clas.abap
@@ -1647,6 +1647,12 @@ CLASS zcl_excel_common IMPLEMENTATION.
         INSERT is_component INTO TABLE xt_components.
       WHEN cl_abap_typedescr=>kind_struct. "S Structure
         lt_comp_str = structure_recursive( is_component = is_component ).
+
+        " When the structure has a suffix, all fields in the structure should finish with the suffix
+        loop at lt_comp_str assigning field-symbol(<ls_comp_str>).
+          <ls_comp_str>-name = |{ <ls_comp_str>-name }{ is_component-suffix }|.
+        endloop.
+
         INSERT LINES OF lt_comp_str INTO TABLE xt_components.
       WHEN OTHERS. "cl_abap_typedescr=>kind_ref or  cl_abap_typedescr=>kind_class or  cl_abap_typedescr=>kind_intf.
 * We skip it. for now.

--- a/src/zcl_excel_common.clas.abap
+++ b/src/zcl_excel_common.clas.abap
@@ -1639,6 +1639,7 @@ CLASS zcl_excel_common IMPLEMENTATION.
 
   METHOD structure_case.
     DATA: lt_comp_str        TYPE abap_component_tab.
+    FIELD-SYMBOLS: <ls_comp_str> TYPE abap_componentdescr.
 
     CASE is_component-type->kind.
       WHEN cl_abap_typedescr=>kind_elem. "E Elementary Type
@@ -1649,7 +1650,7 @@ CLASS zcl_excel_common IMPLEMENTATION.
         lt_comp_str = structure_recursive( is_component = is_component ).
 
         " When the structure has a suffix, all fields in the structure should finish with the suffix
-        loop at lt_comp_str assigning field-symbol(<ls_comp_str>).
+        loop at lt_comp_str assigning <ls_comp_str>.
           <ls_comp_str>-name = |{ <ls_comp_str>-name }{ is_component-suffix }|.
         endloop.
 

--- a/src/zcl_excel_common.clas.abap
+++ b/src/zcl_excel_common.clas.abap
@@ -1652,7 +1652,7 @@ CLASS zcl_excel_common IMPLEMENTATION.
         " When the structure has a suffix, all fields in the structure should finish with the suffix
         LOOP AT lt_comp_str ASSIGNING <ls_comp_str>.
           <ls_comp_str>-name = |{ <ls_comp_str>-name }{ is_component-suffix }|.
-        endloop.
+        ENDLOOP.
 
         INSERT LINES OF lt_comp_str INTO TABLE xt_components.
       WHEN OTHERS. "cl_abap_typedescr=>kind_ref or  cl_abap_typedescr=>kind_class or  cl_abap_typedescr=>kind_intf.

--- a/src/zcl_excel_common.clas.abap
+++ b/src/zcl_excel_common.clas.abap
@@ -1654,7 +1654,7 @@ CLASS zcl_excel_common IMPLEMENTATION.
           LOOP AT lt_comp_str ASSIGNING <ls_comp_str>.
             <ls_comp_str>-name = |{ <ls_comp_str>-name }{ is_component-suffix }|.
           ENDLOOP.
-        ENDIF
+        ENDIF.
 
         INSERT LINES OF lt_comp_str INTO TABLE xt_components.
       WHEN OTHERS. "cl_abap_typedescr=>kind_ref or  cl_abap_typedescr=>kind_class or  cl_abap_typedescr=>kind_intf.

--- a/src/zcl_excel_common.clas.abap
+++ b/src/zcl_excel_common.clas.abap
@@ -1649,10 +1649,12 @@ CLASS zcl_excel_common IMPLEMENTATION.
       WHEN cl_abap_typedescr=>kind_struct. "S Structure
         lt_comp_str = structure_recursive( is_component = is_component ).
 
-        " When the structure has a suffix, all fields in the structure should finish with the suffix
-        LOOP AT lt_comp_str ASSIGNING <ls_comp_str>.
-          <ls_comp_str>-name = |{ <ls_comp_str>-name }{ is_component-suffix }|.
-        ENDLOOP.
+        IF is_component-suffix IS NOT INITIAL.
+          " When the structure has a suffix, all fields in the structure should finish with the suffix
+          LOOP AT lt_comp_str ASSIGNING <ls_comp_str>.
+            <ls_comp_str>-name = |{ <ls_comp_str>-name }{ is_component-suffix }|.
+          ENDLOOP.
+        ENDIF
 
         INSERT LINES OF lt_comp_str INTO TABLE xt_components.
       WHEN OTHERS. "cl_abap_typedescr=>kind_ref or  cl_abap_typedescr=>kind_class or  cl_abap_typedescr=>kind_intf.

--- a/src/zcl_excel_common.clas.abap
+++ b/src/zcl_excel_common.clas.abap
@@ -1650,7 +1650,7 @@ CLASS zcl_excel_common IMPLEMENTATION.
         lt_comp_str = structure_recursive( is_component = is_component ).
 
         " When the structure has a suffix, all fields in the structure should finish with the suffix
-        loop at lt_comp_str assigning <ls_comp_str>.
+        LOOP AT lt_comp_str ASSIGNING <ls_comp_str>.
           <ls_comp_str>-name = |{ <ls_comp_str>-name }{ is_component-suffix }|.
         endloop.
 


### PR DESCRIPTION
fix bug:
When a structure has a suffix, all fields in the structure should finish with the suffix