### PR TITLE
Non-Unicode fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ output
 foo.zip
 foo.xlsx
 foo
+.DS_Store

--- a/src/zcl_excel_common.clas.abap
+++ b/src/zcl_excel_common.clas.abap
@@ -218,7 +218,7 @@ CLASS zcl_excel_common DEFINITION
         zcx_excel .
     CLASS-METHODS is_unicode_system
       RETURNING
-        VALUE(rv_is_unicode) TYPE abap_bool .		
+        VALUE(rv_is_unicode) TYPE abap_bool .
 *"* protected components of class ZCL_EXCEL_COMMON
 *"* do not include other source files here!!!
 *"* protected components of class ZCL_EXCEL_COMMON
@@ -1047,8 +1047,6 @@ CLASS zcl_excel_common IMPLEMENTATION.
 
   METHOD is_unicode_system.
 
-    DATA: lv_unicode_check TYPE c LENGTH 5.
-
     " Cache the result as static variable for performance
     STATICS: sv_cached     TYPE abap_bool,
              sv_is_unicode TYPE abap_bool.
@@ -1058,10 +1056,7 @@ CLASS zcl_excel_common IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    CALL 'C_SAPGPARAM' ID 'NAME'  FIELD 'abap/unicode_check'
-                       ID 'VALUE' FIELD lv_unicode_check. "#EC CI_CCALL
-
-    IF lv_unicode_check CS 'on'.
+    IF cl_abap_char_utilities=>charsize > 1.
       sv_is_unicode = abap_true.
     ELSE.
       sv_is_unicode = abap_false.

--- a/src/zcl_excel_common.clas.abap
+++ b/src/zcl_excel_common.clas.abap
@@ -1047,23 +1047,7 @@ CLASS zcl_excel_common IMPLEMENTATION.
 
   METHOD is_unicode_system.
 
-    " Cache the result as static variable for performance
-    STATICS: sv_cached     TYPE abap_bool,
-             sv_is_unicode TYPE abap_bool.
-
-    IF sv_cached = abap_true.
-      rv_is_unicode = sv_is_unicode.
-      RETURN.
-    ENDIF.
-
-    IF cl_abap_char_utilities=>charsize > 1.
-      sv_is_unicode = abap_true.
-    ELSE.
-      sv_is_unicode = abap_false.
-    ENDIF.
-
-    sv_cached = abap_true.
-    rv_is_unicode = sv_is_unicode.
+    rv_is_unicode = boolc( cl_abap_char_utilities=>charsize > 1 ).
 
   ENDMETHOD.
 

--- a/src/zcl_excel_common.clas.abap
+++ b/src/zcl_excel_common.clas.abap
@@ -216,6 +216,9 @@ CLASS zcl_excel_common DEFINITION
         VALUE(rp_in_range) TYPE abap_bool
       RAISING
         zcx_excel .
+    CLASS-METHODS is_unicode_system
+      RETURNING
+        VALUE(rv_is_unicode) TYPE abap_bool .		
 *"* protected components of class ZCL_EXCEL_COMMON
 *"* do not include other source files here!!!
 *"* protected components of class ZCL_EXCEL_COMMON
@@ -1039,6 +1042,34 @@ CLASS zcl_excel_common IMPLEMENTATION.
        ip_row      <= lv_row_end.
       rp_in_range = abap_true.
     ENDIF.
+  ENDMETHOD.
+
+
+  METHOD is_unicode_system.
+
+    DATA: lv_unicode_check TYPE c LENGTH 5.
+
+    " Cache the result as static variable for performance
+    STATICS: sv_cached     TYPE abap_bool,
+             sv_is_unicode TYPE abap_bool.
+
+    IF sv_cached = abap_true.
+      rv_is_unicode = sv_is_unicode.
+      RETURN.
+    ENDIF.
+
+    CALL 'C_SAPGPARAM' ID 'NAME'  FIELD 'abap/unicode_check'
+                       ID 'VALUE' FIELD lv_unicode_check. "#EC CI_CCALL
+
+    IF lv_unicode_check CS 'on'.
+      sv_is_unicode = abap_true.
+    ELSE.
+      sv_is_unicode = abap_false.
+    ENDIF.
+
+    sv_cached = abap_true.
+    rv_is_unicode = sv_is_unicode.
+
   ENDMETHOD.
 
 

--- a/src/zcl_excel_reader_2007.clas.abap
+++ b/src/zcl_excel_reader_2007.clas.abap
@@ -663,6 +663,7 @@ CLASS zcl_excel_reader_2007 IMPLEMENTATION.
           lv_content_mod   TYPE xstring,	
           lo_ixml          TYPE REF TO if_ixml,
           lo_streamfactory TYPE REF TO if_ixml_stream_factory,
+          lo_istream       TYPE REF TO if_ixml_istream,		  
           lo_parser        TYPE REF TO if_ixml_parser,
           lo_conv_in       TYPE REF TO cl_abap_conv_in_ce.
 

--- a/src/zcl_excel_reader_2007.clas.abap
+++ b/src/zcl_excel_reader_2007.clas.abap
@@ -660,10 +660,10 @@ CLASS zcl_excel_reader_2007 IMPLEMENTATION.
 
     DATA: lv_content       TYPE xstring,
           lv_string        TYPE string,
-          lv_content_mod   TYPE xstring,	
+          lv_content_mod   TYPE xstring,
           lo_ixml          TYPE REF TO if_ixml,
           lo_streamfactory TYPE REF TO if_ixml_stream_factory,
-          lo_istream       TYPE REF TO if_ixml_istream,		  
+          lo_istream       TYPE REF TO if_ixml_istream,
           lo_parser        TYPE REF TO if_ixml_parser,
           lo_conv_in       TYPE REF TO cl_abap_conv_in_ce.
 

--- a/src/zcl_excel_reader_2007.clas.abap
+++ b/src/zcl_excel_reader_2007.clas.abap
@@ -659,10 +659,12 @@ CLASS zcl_excel_reader_2007 IMPLEMENTATION.
 * Do not use method IF_IXML_STREAM_FACTORY=>CREATE_ISTREAM_CSTRING in this context as it shows the unwanted behaviour.
 
     DATA: lv_content       TYPE xstring,
+          lv_string        TYPE string,
+          lv_content_mod   TYPE xstring,	
           lo_ixml          TYPE REF TO if_ixml,
           lo_streamfactory TYPE REF TO if_ixml_stream_factory,
-          lo_istream       TYPE REF TO if_ixml_istream,
-          lo_parser        TYPE REF TO if_ixml_parser.
+          lo_parser        TYPE REF TO if_ixml_parser,
+          lo_conv_in       TYPE REF TO cl_abap_conv_in_ce.
 
 *--------------------------------------------------------------------*
 * Load XML file from archive into an input stream,
@@ -671,8 +673,50 @@ CLASS zcl_excel_reader_2007 IMPLEMENTATION.
     lv_content        = me->get_from_zip_archive( i_filename ).
     lo_ixml           = cl_ixml=>create( ).
     lo_streamfactory  = lo_ixml->create_stream_factory( ).
-*   lo_istream        = lo_streamfactory->create_istream_xstring( lv_content ).
-    lo_istream        = lo_streamfactory->create_istream_string( cl_abap_codepage=>convert_from( lv_content ) ).
+
+*--------------------------------------------------------------------*
+* Convert content - handle Unicode and non-Unicode systems
+*--------------------------------------------------------------------*
+    IF zcl_excel_common=>is_unicode_system( ) = abap_true.
+*     Unicode system - original logic unchanged
+      lo_istream = lo_streamfactory->create_istream_string( cl_abap_codepage=>convert_from( lv_content ) ).
+    ELSE.
+*     Non-Unicode system - convert via ISO-8859-1 and use xstring stream
+*     UTF-8 codepage (4110) is not available, so we must use a different approach
+      TRY.
+*         Read UTF-8 content as ISO-8859-1 (single-byte, won't fail on conversion)
+          lo_conv_in = cl_abap_conv_in_ce=>create(
+              input    = lv_content
+              encoding = 'ISO-8859-1' ).
+          lo_conv_in->read( IMPORTING data = lv_string ).
+
+*         Replace UTF-8 encoding declaration with ISO-8859-1 so iXML parser accepts it
+          REPLACE 'encoding="UTF-8"' IN lv_string WITH 'encoding="ISO-8859-1"' IGNORING CASE.
+
+*         Convert string back to xstring using function module
+          CALL FUNCTION 'SCMS_STRING_TO_XSTRING'
+            EXPORTING
+              text     = lv_string
+              encoding = '1100'          " ISO-8859-1 codepage
+            IMPORTING
+              buffer   = lv_content_mod
+            EXCEPTIONS
+              failed   = 1
+              OTHERS   = 2.
+
+          IF sy-subrc = 0.
+            lo_istream = lo_streamfactory->create_istream_xstring( lv_content_mod ).
+          ELSE.
+*           Fallback if conversion failed
+            lo_istream = lo_streamfactory->create_istream_xstring( lv_content ).
+          ENDIF.
+
+        CATCH cx_root.
+*         Fallback - try original content directly
+          lo_istream = lo_streamfactory->create_istream_xstring( lv_content ).
+      ENDTRY.
+    ENDIF.
+
     r_ixml            = lo_ixml->create_document( ).
     lo_parser         = lo_ixml->create_parser( stream_factory = lo_streamfactory
                                                 istream        = lo_istream

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -307,7 +307,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
           lv_unicode_point_code  TYPE i.
     DATA: lv_hex TYPE x LENGTH 1,
           lv_char TYPE c LENGTH 1.
-    DATA: lv_result(5) type C.
+    DATA: lv_result(5) TYPE C.
 
     me->ixml = cl_ixml=>create( ).
 

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -302,20 +302,46 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 
 
   METHOD constructor.
+
     DATA: lt_unicode_point_codes TYPE TABLE OF string,
           lv_unicode_point_code  TYPE i.
+    DATA: lv_hex TYPE x LENGTH 1,
+          lv_char TYPE c LENGTH 1.
+    DATA: lv_result(5) type C.
 
     me->ixml = cl_ixml=>create( ).
 
-    SPLIT '0,1,2,3,4,5,6,7,8,' " U+0000 to U+0008
-       && '11,12,'             " U+000B, U+000C
-       && '14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,' " U+000E to U+001F
-       && '65534,65535'        " U+FFFE, U+FFFF
-      AT ',' INTO TABLE lt_unicode_point_codes.
-    control_characters = ``.
-    LOOP AT lt_unicode_point_codes INTO lv_unicode_point_code.
-      control_characters = control_characters && cl_abap_conv_in_ce=>uccpi( lv_unicode_point_code ).
-    ENDLOOP.
+    IF zcl_excel_common=>is_unicode_system( ) = abap_true.
+      " Unicode system -
+        SPLIT '0,1,2,3,4,5,6,7,8,' " U+0000 to U+0008
+           && '11,12,'             " U+000B, U+000C
+           && '14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,' " U+000E to U+001F
+           && '65534,65535'        " U+FFFE, U+FFFF
+          AT ',' INTO TABLE lt_unicode_point_codes.
+        control_characters = ``.
+        LOOP AT lt_unicode_point_codes INTO lv_unicode_point_code.
+          control_characters = control_characters && cl_abap_conv_in_ce=>uccpi( lv_unicode_point_code ).
+        ENDLOOP.
+
+    ELSE.
+      " Non-Unicode system - only code points within single-byte range
+      " Skip U+FFFE and U+FFFF as they don't exist in non-Unicode systems
+      SPLIT '0,1,2,3,4,5,6,7,8,'
+         && '11,12,'
+         && '14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31'
+        AT ',' INTO TABLE lt_unicode_point_codes.
+      control_characters = ``.
+      LOOP AT lt_unicode_point_codes INTO lv_unicode_point_code.
+        TRY.
+            control_characters = control_characters && cl_abap_conv_in_ce=>uccpi( lv_unicode_point_code ).
+          CATCH cx_sy_conversion_codepage
+                cx_sy_codepage_converter_init
+                cx_parameter_invalid_range.
+            " Skip characters that can't be converted
+            CONTINUE.
+        ENDTRY.
+      ENDLOOP.
+    ENDIF.
 
   ENDMETHOD.
 
@@ -5637,7 +5663,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
     IF io_table->settings-table_name IS NOT INITIAL AND lv_match EQ 0.
       " Name rules (https://support.microsoft.com/en-us/office/rename-an-excel-table-fbf49a4f-82a3-43eb-8ba2-44d21233b114)
       "   - You can't use "C", "c", "R", or "r" for the name, because they're already designated as a shortcut for selecting the column or row for the active cell when you enter them in the Name or Go To box.
-      "   - Don't use cell references — Names can't be the same as a cell reference, such as Z$100 or R1C1
+      "   - Don't use cell references - Names can't be the same as a cell reference, such as Z$100 or R1C1
       IF ( strlen( io_table->settings-table_name ) = 1 AND io_table->settings-table_name CO 'CcRr' )
          OR zcl_excel_common=>shift_formula(
               iv_reference_formula = io_table->settings-table_name
@@ -6102,9 +6128,16 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
 
 
   METHOD create_xml_document.
+
     DATA lo_encoding TYPE REF TO if_ixml_encoding.
-    lo_encoding = me->ixml->create_encoding( byte_order = if_ixml_encoding=>co_platform_endian
-                                             character_set = 'utf-8' ).
+    IF zcl_excel_common=>is_unicode_system( ) = abap_true.
+      " Unicode system - standard conversion
+        lo_encoding = me->ixml->create_encoding( byte_order = if_ixml_encoding=>co_platform_endian
+                                                 character_set = 'utf-8' ).
+    ELSE.                           "non-Unicode system
+        lo_encoding = me->ixml->create_encoding( byte_order    = if_ixml_encoding=>co_platform_endian
+                                                 character_set = 'iso-8859-1' ).
+    ENDIF.
     ro_document = me->ixml->create_document( ).
     ro_document->set_encoding( lo_encoding ).
     ro_document->set_standalone( abap_true ).

--- a/src/zcl_excel_writer_2007.clas.abap
+++ b/src/zcl_excel_writer_2007.clas.abap
@@ -307,7 +307,7 @@ CLASS zcl_excel_writer_2007 IMPLEMENTATION.
           lv_unicode_point_code  TYPE i.
     DATA: lv_hex TYPE x LENGTH 1,
           lv_char TYPE c LENGTH 1.
-    DATA: lv_result(5) TYPE C.
+    DATA: lv_result(5) TYPE c.
 
     me->ixml = cl_ixml=>create( ).
 


### PR DESCRIPTION
These fixes check for a non-Unicode system to make the demo programs work and avoid code page conversion dumps.
Tested on a 740 ABAP system with non-Unicode. 