### PR TITLE
Feature: copy/clone worksheet

### DIFF
--- a/src/zcl_excel.clas.abap
+++ b/src/zcl_excel.clas.abap
@@ -51,21 +51,21 @@ CLASS zcl_excel DEFINITION
     "! Creates a new worksheet that is a deep copy of <em>io_source</em>.
     "!
     "! Behaviour mirrors <em>add_new_worksheet</em>: the new sheet is appended,
-    "! becomes the active sheet, and is returned. 
-    "! 
+    "! becomes the active sheet, and is returned.
+    "!
     "! The copy is generally "disconnected": subsequent changes on the new worksheet do
-    "! should not affect the source worksheet. 
+    "! should not affect the source worksheet.
     "! However, there are exceptions from this rule:
     "!  - Style GUIDs that live in the workbook-wide  styles collection are intentionally
-    "!    shared - you may follow up with <em>add_new_style</em> to fork a style if independent 
+    "!    shared - you may follow up with <em>add_new_style</em> to fork a style if independent
     "!    in edits are required.
     "!  - Drawings are copied 'by reference'.
-    "! 
+    "!
     "! Use the optional <em>is_options</em> structure (skip-flags, default = include everything)
     "! to limit which categories of content are copied; see <em>zcl_excel_worksheet=&gt;ts_clone_options</em>.
     "!
     "! @parameter io_source | The source worksheet (must belong to this workbook).
-    "! @parameter iv_title | Title of the new worksheet. 
+    "! @parameter iv_title | Title of the new worksheet.
     "! @parameter is_options | Skip-flags controlling what to copy.
     "! @parameter eo_worksheet | The newly created cloned worksheet.
     "! @raising zcx_excel | If the source is invalid or no unique title can be derived.

--- a/src/zcl_excel.clas.abap
+++ b/src/zcl_excel.clas.abap
@@ -48,6 +48,36 @@ CLASS zcl_excel DEFINITION
         VALUE(eo_worksheet) TYPE REF TO zcl_excel_worksheet
       RAISING
         zcx_excel .
+    "! Creates a new worksheet that is a deep copy of <em>io_source</em>.
+    "!
+    "! Behaviour mirrors <em>add_new_worksheet</em>: the new sheet is appended,
+    "! becomes the active sheet, and is returned. 
+    "! 
+    "! The copy is generally "disconnected": subsequent changes on the new worksheet do
+    "! should not affect the source worksheet. 
+    "! However, there are exceptions from this rule:
+    "!  - Style GUIDs that live in the workbook-wide  styles collection are intentionally
+    "!    shared - you may follow up with <em>add_new_style</em> to fork a style if independent 
+    "!    in edits are required.
+    "!  - Drawings are copied 'by reference'.
+    "! 
+    "! Use the optional <em>is_options</em> structure (skip-flags, default = include everything)
+    "! to limit which categories of content are copied; see <em>zcl_excel_worksheet=&gt;ts_clone_options</em>.
+    "!
+    "! @parameter io_source | The source worksheet (must belong to this workbook).
+    "! @parameter iv_title | Title of the new worksheet. 
+    "! @parameter is_options | Skip-flags controlling what to copy.
+    "! @parameter eo_worksheet | The newly created cloned worksheet.
+    "! @raising zcx_excel | If the source is invalid or no unique title can be derived.
+    METHODS clone_worksheet
+      IMPORTING
+        !io_source          TYPE REF TO zcl_excel_worksheet
+        !iv_title           TYPE zexcel_sheet_title
+        !is_options         TYPE zcl_excel_worksheet=>ts_clone_options OPTIONAL
+      RETURNING
+        VALUE(eo_worksheet) TYPE REF TO zcl_excel_worksheet
+      RAISING
+        zcx_excel .
     METHODS add_static_styles .
     METHODS constructor .
     METHODS delete_worksheet
@@ -260,6 +290,32 @@ CLASS zcl_excel IMPLEMENTATION.
 
     worksheets->add( eo_worksheet ).
     worksheets->active_worksheet = worksheets->size( ).
+  ENDMETHOD.
+
+
+  METHOD clone_worksheet.
+
+    DATA lo_existing TYPE REF TO zcl_excel_worksheet.
+
+    IF io_source IS NOT BOUND.
+      zcx_excel=>raise_text( 'Source worksheet not bound' ).
+    ENDIF.
+    IF io_source->excel <> me.
+      zcx_excel=>raise_text( 'Source worksheet belongs to another workbook' ).
+    ENDIF.
+    IF iv_title IS INITIAL.
+      zcx_excel=>raise_text( 'Title is mandatory' ).
+    ELSE.
+      lo_existing = get_worksheet_by_name( iv_title ).
+      IF lo_existing IS NOT INITIAL.
+        zcx_excel=>raise_text( 'Worksheet with this name already exists' ).
+      ENDIF.
+    ENDIF.
+
+    eo_worksheet = me->add_new_worksheet( ip_title = iv_title ).
+    eo_worksheet->clone_from( io_source  = io_source
+                              is_options = is_options ).
+
   ENDMETHOD.
 
 

--- a/src/zcl_excel_autofilter.clas.abap
+++ b/src/zcl_excel_autofilter.clas.abap
@@ -1,7 +1,8 @@
 CLASS zcl_excel_autofilter DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel_worksheet .
 
 *"* public components of class ZCL_EXCEL_AUTOFILTER
 *"* do not include other source files here!!!

--- a/src/zcl_excel_autofilter.clas.abap
+++ b/src/zcl_excel_autofilter.clas.abap
@@ -94,6 +94,14 @@ CLASS zcl_excel_autofilter DEFINITION
         !is_filter          TYPE ts_filter
       RETURNING
         VALUE(rv_is_hidden) TYPE abap_bool .
+
+    "! Returns a deep copy of this autofilter, bound to the supplied worksheet.
+    METHODS clone
+      IMPORTING
+        !io_sheet       TYPE REF TO zcl_excel_worksheet
+      RETURNING
+        VALUE(eo_clone) TYPE REF TO zcl_excel_autofilter .
+
 *"* private components of class ZCL_EXCEL_AUTOFILTER
 *"* do not include other source files here!!!
   PRIVATE SECTION.
@@ -113,6 +121,14 @@ CLASS zcl_excel_autofilter IMPLEMENTATION.
 
   METHOD constructor.
     worksheet = io_sheet.
+  ENDMETHOD.
+
+  METHOD clone.
+    CREATE OBJECT eo_clone
+      EXPORTING
+        io_sheet = io_sheet.
+    eo_clone->filter_area = me->filter_area.
+    eo_clone->mt_filters  = me->mt_filters.
   ENDMETHOD.
 
 

--- a/src/zcl_excel_autofilter.clas.abap
+++ b/src/zcl_excel_autofilter.clas.abap
@@ -32,6 +32,11 @@ CLASS zcl_excel_autofilter DEFINITION
     METHODS constructor
       IMPORTING
         !io_sheet TYPE REF TO zcl_excel_worksheet .
+
+    METHODS get_worksheet
+      RETURNING
+        VALUE(ro_sheet) TYPE REF TO zcl_excel_worksheet.
+
     METHODS get_filter_area
       RETURNING
         VALUE(rs_area) TYPE zexcel_s_autofilter_area
@@ -121,6 +126,10 @@ CLASS zcl_excel_autofilter IMPLEMENTATION.
 
   METHOD constructor.
     worksheet = io_sheet.
+  ENDMETHOD.
+
+  METHOD get_worksheet.
+    ro_sheet = worksheet.
   ENDMETHOD.
 
   METHOD clone.

--- a/src/zcl_excel_autofilters.clas.abap
+++ b/src/zcl_excel_autofilters.clas.abap
@@ -1,7 +1,8 @@
 CLASS zcl_excel_autofilters DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel_worksheet.
 
   PUBLIC SECTION.
 *"* public components of class ZCL_EXCEL_AUTOFILTERS

--- a/src/zcl_excel_autofilters.clas.abap
+++ b/src/zcl_excel_autofilters.clas.abap
@@ -10,6 +10,7 @@ CLASS zcl_excel_autofilters DEFINITION
 
     CONSTANTS c_autofilter TYPE string VALUE '_xlnm._FilterDatabase'. "#EC NOTEXT
 
+    "! Adds a new (empty) autofilter associated with a worksheet to the collection.
     METHODS add
       IMPORTING
         !io_sheet            TYPE REF TO zcl_excel_worksheet
@@ -17,7 +18,9 @@ CLASS zcl_excel_autofilters DEFINITION
         VALUE(ro_autofilter) TYPE REF TO zcl_excel_autofilter
       RAISING
         zcx_excel .
+
     METHODS clear .
+
     METHODS get
       IMPORTING
         !io_worksheet        TYPE REF TO zcl_excel_worksheet
@@ -37,6 +40,14 @@ CLASS zcl_excel_autofilters DEFINITION
 *"* protected components of class ZABAP_EXCEL_WORKSHEETS
 *"* do not include other source files here!!!
   PROTECTED SECTION.
+
+    "! Adds a pre-built autofilter (e.g. a clone) into the collection.
+    METHODS add_existing
+      IMPORTING
+        !io_autofilter TYPE REF TO zcl_excel_autofilter
+      RAISING
+        zcx_excel .
+
   PRIVATE SECTION.
 
     TYPES:
@@ -81,6 +92,26 @@ CLASS zcl_excel_autofilters IMPLEMENTATION.
   METHOD clear.
 
     CLEAR me->mt_autofilters.
+
+  ENDMETHOD.
+
+
+  METHOD add_existing.
+
+    DATA: ls_autofilter LIKE LINE OF me->mt_autofilters.
+
+    DATA lo_worksheet TYPE REF TO zcl_excel_worksheet.
+
+    lo_worksheet = io_autofilter->get_worksheet( ).
+
+    READ TABLE me->mt_autofilters TRANSPORTING NO FIELDS WITH TABLE KEY worksheet = lo_worksheet.
+    IF sy-subrc = 0.
+      RAISE EXCEPTION TYPE zcx_excel. " sheet already has an autofilter
+    ENDIF.
+
+    ls_autofilter-worksheet  = lo_worksheet.
+    ls_autofilter-autofilter = io_autofilter.
+    INSERT ls_autofilter INTO TABLE me->mt_autofilters.
 
   ENDMETHOD.
 

--- a/src/zcl_excel_column.clas.abap
+++ b/src/zcl_excel_column.clas.abap
@@ -1,7 +1,8 @@
 CLASS zcl_excel_column DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel_worksheet .
 
 *"* public components of class ZCL_EXCEL_COLUMN
 *"* do not include other source files here!!!

--- a/src/zcl_excel_column.clas.abap
+++ b/src/zcl_excel_column.clas.abap
@@ -86,6 +86,16 @@ CLASS zcl_excel_column DEFINITION
 *"* protected components of class ZCL_EXCEL_COLUMN
 *"* do not include other source files here!!!
   PROTECTED SECTION.
+    "! Returns a deep copy of this column attached to the supplied worksheet.
+    "! The column index is kept, the index must be 'free' in the target worksheet.
+    METHODS clone
+      IMPORTING
+        !io_worksheet   TYPE REF TO zcl_excel_worksheet
+      RETURNING
+        VALUE(eo_clone) TYPE REF TO zcl_excel_column
+      RAISING
+        zcx_excel .
+
 *"* private components of class ZCL_EXCEL_COLUMN
 *"* do not include other source files here!!!
   PRIVATE SECTION.
@@ -125,6 +135,26 @@ CLASS zcl_excel_column IMPLEMENTATION.
 
   METHOD get_auto_size.
     r_auto_size = me->auto_size.
+  ENDMETHOD.
+
+
+  METHOD clone.
+    DATA: lv_index_alpha TYPE zexcel_cell_column_alpha.
+
+    lv_index_alpha = zcl_excel_common=>convert_column2alpha( me->column_index ).
+    CREATE OBJECT eo_clone
+      EXPORTING
+        ip_index     = lv_index_alpha
+        ip_excel     = io_worksheet->excel
+        ip_worksheet = io_worksheet.
+
+    eo_clone->width         = me->width.
+    eo_clone->auto_size     = me->auto_size.
+    eo_clone->visible       = me->visible.
+    eo_clone->outline_level = me->outline_level.
+    eo_clone->collapsed     = me->collapsed.
+    eo_clone->xf_index      = me->xf_index.
+    eo_clone->style_guid    = me->style_guid.
   ENDMETHOD.
 
 

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -1,7 +1,8 @@
 CLASS zcl_excel_comment DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel_worksheet .
 
   PUBLIC SECTION.
 

--- a/src/zcl_excel_comment.clas.abap
+++ b/src/zcl_excel_comment.clas.abap
@@ -84,6 +84,10 @@ CLASS zcl_excel_comment DEFINITION
         !ip_bottom_offset TYPE i DEFAULT gc_default_box-bottom_offset.
 
   PROTECTED SECTION.
+    "! Returns a deep copy of this comment.
+    METHODS clone
+      RETURNING
+        VALUE(eo_clone) TYPE REF TO zcl_excel_comment .
   PRIVATE SECTION.
 
     DATA index TYPE string .
@@ -196,6 +200,15 @@ CLASS zcl_excel_comment IMPLEMENTATION.
 
     gs_box = is_box.
 
+  ENDMETHOD.
+
+
+  METHOD clone.
+    CREATE OBJECT eo_clone.
+    eo_clone->index  = me->index.
+    eo_clone->ref    = me->ref.
+    eo_clone->text   = me->text.
+    eo_clone->gs_box = me->gs_box.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/zcl_excel_data_validation.clas.abap
+++ b/src/zcl_excel_data_validation.clas.abap
@@ -51,6 +51,11 @@ CLASS zcl_excel_data_validation DEFINITION
 *"* protected components of class ZCL_EXCEL_DATA_VALIDATION
 *"* do not include other source files here!!!
   PROTECTED SECTION.
+   "! Returns a deep copy of this data validation rule.
+    METHODS clone
+      RETURNING
+        VALUE(eo_clone) TYPE REF TO zcl_excel_data_validation .
+
   PRIVATE SECTION.
 *"* private components of class ZCL_EXCEL_DATA_VALIDATION
 *"* do not include other source files here!!!
@@ -79,5 +84,27 @@ CLASS zcl_excel_data_validation IMPLEMENTATION.
 * inizialize dimension range
     cell_row     = 1.
     cell_column  = 'A'.
+  ENDMETHOD.
+
+
+  METHOD clone.
+    CREATE OBJECT eo_clone.
+    eo_clone->errorstyle       = me->errorstyle.
+    eo_clone->operator         = me->operator.
+    eo_clone->allowblank       = me->allowblank.
+    eo_clone->cell_column      = me->cell_column.
+    eo_clone->cell_column_to   = me->cell_column_to.
+    eo_clone->cell_row         = me->cell_row.
+    eo_clone->cell_row_to      = me->cell_row_to.
+    eo_clone->showerrormessage = me->showerrormessage.
+    eo_clone->showinputmessage = me->showinputmessage.
+    eo_clone->type             = me->type.
+    eo_clone->formula1         = me->formula1.
+    eo_clone->formula2         = me->formula2.
+    eo_clone->showdropdown     = me->showdropdown.
+    eo_clone->errortitle       = me->errortitle.
+    eo_clone->error            = me->error.
+    eo_clone->prompttitle      = me->prompttitle.
+    eo_clone->prompt           = me->prompt.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_excel_data_validation.clas.abap
+++ b/src/zcl_excel_data_validation.clas.abap
@@ -1,7 +1,8 @@
 CLASS zcl_excel_data_validation DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel_worksheet .
 
   PUBLIC SECTION.
 *"* public components of class ZCL_EXCEL_DATA_VALIDATION

--- a/src/zcl_excel_drawing.clas.abap
+++ b/src/zcl_excel_drawing.clas.abap
@@ -122,6 +122,12 @@ CLASS zcl_excel_drawing DEFINITION
       IMPORTING
         VALUE(ip_chart) TYPE REF TO if_ixml_document .
   PROTECTED SECTION.
+    "! Returns a deep copy of this drawing with a new GUID. The graph reference,
+    "! if any, is shared (shallow copy) since drawing configuration is large and
+    "! is generally treated as immutable per drawing.
+    METHODS clone
+      RETURNING
+        VALUE(eo_clone) TYPE REF TO zcl_excel_drawing .
   PRIVATE SECTION.
 
 *"* private components of class ZCL_EXCEL_DRAWING
@@ -167,6 +173,34 @@ CLASS ZCL_EXCEL_DRAWING IMPLEMENTATION.
     anchor = anchor_one_cell.
     from_loc-col = 1.
     from_loc-row = 1.
+  ENDMETHOD.
+
+
+  METHOD clone.
+    "Create a new drawing instance; constructor will regenerate guid.
+    CREATE OBJECT eo_clone
+      EXPORTING
+        ip_type  = me->type
+        ip_title = me->title.
+
+    "Copy public attributes
+    eo_clone->graph_type = me->graph_type.
+    eo_clone->title      = me->title.
+    eo_clone->graph      = me->graph.   " shallow share of chart graph configuration
+
+    "Copy private attributes
+    eo_clone->anchor        = me->anchor.
+    eo_clone->media         = me->media.
+    eo_clone->media_key_www = me->media_key_www.
+    eo_clone->media_source  = me->media_source.
+    eo_clone->media_type    = me->media_type.
+    eo_clone->io            = me->io.
+    eo_clone->from_loc      = me->from_loc.
+    eo_clone->to_loc        = me->to_loc.
+    eo_clone->size          = me->size.
+
+    "Note: do NOT copy media_name / index here - they are reassigned by
+    "zcl_excel_drawings=>add when this clone is added to a drawings collection.
   ENDMETHOD.
 
 

--- a/src/zcl_excel_drawing.clas.abap
+++ b/src/zcl_excel_drawing.clas.abap
@@ -1,7 +1,8 @@
 CLASS zcl_excel_drawing DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel_worksheet .
 
   PUBLIC SECTION.
     CONSTANTS c_graph_pie TYPE zexcel_graph_type VALUE 1.   "#EC NOTEXT

--- a/src/zcl_excel_hyperlink.clas.abap
+++ b/src/zcl_excel_hyperlink.clas.abap
@@ -1,7 +1,8 @@
 CLASS zcl_excel_hyperlink DEFINITION
   PUBLIC
   FINAL
-  CREATE PRIVATE .
+  CREATE PRIVATE
+  GLOBAL FRIENDS zcl_excel_worksheet .
 
 *"* public components of class ZCL_EXCEL_HYPERLINK
 *"* do not include other source files here!!!

--- a/src/zcl_excel_hyperlink.clas.abap
+++ b/src/zcl_excel_hyperlink.clas.abap
@@ -36,6 +36,11 @@ CLASS zcl_excel_hyperlink DEFINITION
 *"* protected components of class ZCL_EXCEL_HYPERLINK
 *"* do not include other source files here!!!
   PROTECTED SECTION.
+    "! Returns a deep copy of this hyperlink.
+    METHODS clone
+      RETURNING
+        VALUE(eo_clone) TYPE REF TO zcl_excel_hyperlink .
+
 *"* private components of class ZCL_EXCEL_HYPERLINK
 *"* do not include other source files here!!!
   PRIVATE SECTION.
@@ -104,5 +109,14 @@ CLASS zcl_excel_hyperlink IMPLEMENTATION.
   METHOD set_cell_reference.
     me->column = zcl_excel_common=>convert_column2alpha( ip_column ). " issue #155 - less restrictive typing for ip_column
     me->row = ip_row.
+  ENDMETHOD.
+
+
+  METHOD clone.
+    eo_clone = zcl_excel_hyperlink=>create( iv_url      = me->location
+                                            iv_internal = me->internal ).
+    eo_clone->cell_reference = me->cell_reference.
+    eo_clone->column         = me->column.
+    eo_clone->row            = me->row.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_excel_range.clas.abap
+++ b/src/zcl_excel_range.clas.abap
@@ -1,7 +1,8 @@
 CLASS zcl_excel_range DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel_worksheet .
 
 *"* public components of class ZCL_EXCEL_RANGE
 *"* do not include other source files here!!!

--- a/src/zcl_excel_range.clas.abap
+++ b/src/zcl_excel_range.clas.abap
@@ -31,6 +31,13 @@ CLASS zcl_excel_range DEFINITION
 *"* protected components of class ZABAP_EXCEL_WORKSHEET
 *"* do not include other source files here!!!
   PROTECTED SECTION.
+    "! Returns a deep copy of this range. The caller is responsible for
+    "! retargeting the range value (e.g. patching the sheet name) when the
+    "! clone is bound to a different worksheet.
+    METHODS clone
+      RETURNING
+        VALUE(eo_clone) TYPE REF TO zcl_excel_range .
+
 *"* private components of class ZCL_EXCEL_RANGE
 *"* do not include other source files here!!!
   PRIVATE SECTION.
@@ -59,6 +66,14 @@ CLASS zcl_excel_range IMPLEMENTATION.
 
   METHOD set_range_value.
     me->value = ip_value.
+  ENDMETHOD.
+
+
+  METHOD clone.
+    CREATE OBJECT eo_clone.
+    eo_clone->name  = me->name.
+    eo_clone->guid  = me->guid. "In theory unused
+    eo_clone->value = me->value.
   ENDMETHOD.
 
 

--- a/src/zcl_excel_row.clas.abap
+++ b/src/zcl_excel_row.clas.abap
@@ -1,7 +1,8 @@
 CLASS zcl_excel_row DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel_worksheet .
 
 *"* public components of class ZCL_EXCEL_ROW
 *"* do not include other source files here!!!

--- a/src/zcl_excel_row.clas.abap
+++ b/src/zcl_excel_row.clas.abap
@@ -64,6 +64,11 @@ CLASS zcl_excel_row DEFINITION
 *"* protected components of class ZCL_EXCEL_ROW
 *"* do not include other source files here!!!
   PROTECTED SECTION.
+    "! Returns a deep copy of this row.
+    "! The row index is kept, the index must be 'free' in the target worksheet into which the row will be inserted.
+    METHODS clone
+      RETURNING
+        VALUE(eo_clone) TYPE REF TO zcl_excel_row .
 *"* private components of class ZCL_EXCEL_ROW
 *"* do not include other source files here!!!
   PRIVATE SECTION.
@@ -93,6 +98,19 @@ CLASS zcl_excel_row IMPLEMENTATION.
     " set row dimension as unformatted by default
     me->xf_index = 0.
     me->custom_height = abap_false.
+  ENDMETHOD.
+
+
+  METHOD clone.
+    CREATE OBJECT eo_clone
+      EXPORTING
+        ip_index = me->row_index.
+    eo_clone->row_height    = me->row_height.
+    eo_clone->visible       = me->visible.
+    eo_clone->outline_level = me->outline_level.
+    eo_clone->collapsed     = me->collapsed.
+    eo_clone->xf_index      = me->xf_index.
+    eo_clone->custom_height = me->custom_height.
   ENDMETHOD.
 
 

--- a/src/zcl_excel_sheet_setup.clas.abap
+++ b/src/zcl_excel_sheet_setup.clas.abap
@@ -151,6 +151,10 @@ CLASS zcl_excel_sheet_setup DEFINITION
         !ep_even_header TYPE zexcel_s_worksheet_head_foot
         !ep_even_footer TYPE zexcel_s_worksheet_head_foot .
   PROTECTED SECTION.
+    "! Returns a deep copy of this sheet setup.
+    METHODS clone
+      RETURNING
+        VALUE(eo_clone) TYPE REF TO zcl_excel_sheet_setup .
 
 *"* protected components of class ZCL_EXCEL_SHEET_SETUP
 *"* do not include other source files here!!!
@@ -475,5 +479,42 @@ CLASS zcl_excel_sheet_setup IMPLEMENTATION.
     IF ip_right IS SUPPLIED.  margin_right  = lv_coef * ip_right. ENDIF.
     IF ip_top IS SUPPLIED.    margin_top    = lv_coef * ip_top. ENDIF.
 
+  ENDMETHOD.
+
+
+  METHOD clone.
+    CREATE OBJECT eo_clone.
+    eo_clone->black_and_white          = me->black_and_white.
+    eo_clone->cell_comments            = me->cell_comments.
+    eo_clone->copies                   = me->copies.
+    eo_clone->diff_oddeven_headerfooter = me->diff_oddeven_headerfooter.
+    eo_clone->draft                    = me->draft.
+    eo_clone->errors                   = me->errors.
+    eo_clone->even_footer              = me->even_footer.
+    eo_clone->even_header              = me->even_header.
+    eo_clone->first_page_number        = me->first_page_number.
+    eo_clone->fit_to_height            = me->fit_to_height.
+    eo_clone->fit_to_page              = me->fit_to_page.
+    eo_clone->fit_to_width             = me->fit_to_width.
+    eo_clone->horizontal_centered      = me->horizontal_centered.
+    eo_clone->horizontal_dpi           = me->horizontal_dpi.
+    eo_clone->margin_bottom            = me->margin_bottom.
+    eo_clone->margin_footer            = me->margin_footer.
+    eo_clone->margin_header            = me->margin_header.
+    eo_clone->margin_left              = me->margin_left.
+    eo_clone->margin_right             = me->margin_right.
+    eo_clone->margin_top               = me->margin_top.
+    eo_clone->odd_footer               = me->odd_footer.
+    eo_clone->odd_header               = me->odd_header.
+    eo_clone->orientation              = me->orientation.
+    eo_clone->page_order               = me->page_order.
+    eo_clone->paper_height             = me->paper_height.
+    eo_clone->paper_size               = me->paper_size.
+    eo_clone->paper_width              = me->paper_width.
+    eo_clone->scale                    = me->scale.
+    eo_clone->use_first_page_num       = me->use_first_page_num.
+    eo_clone->use_printer_defaults     = me->use_printer_defaults.
+    eo_clone->vertical_centered        = me->vertical_centered.
+    eo_clone->vertical_dpi             = me->vertical_dpi.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_excel_sheet_setup.clas.abap
+++ b/src/zcl_excel_sheet_setup.clas.abap
@@ -1,7 +1,8 @@
 CLASS zcl_excel_sheet_setup DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel_worksheet .
 
   PUBLIC SECTION.
 *"* public components of class ZCL_EXCEL_SHEET_SETUP

--- a/src/zcl_excel_style_cond.clas.abap
+++ b/src/zcl_excel_style_cond.clas.abap
@@ -126,6 +126,13 @@ CLASS zcl_excel_style_cond DEFINITION
 *"* protected components of class ZABAP_EXCEL_STYLE_FONT
 *"* do not include other source files here!!!
   PROTECTED SECTION.
+    "! Returns a (semi-)deep copy of this conditional style.
+    "! The cell-style guid (ip_guid) is preserved. Cell styles are workbook-scoped, the copied conditional
+    "! format will reference the existing style.
+    METHODS clone
+      RETURNING
+        VALUE(eo_clone) TYPE REF TO zcl_excel_style_cond .
+
   PRIVATE SECTION.
 
     DATA mv_rule_range TYPE string .
@@ -240,5 +247,23 @@ CLASS zcl_excel_style_cond IMPLEMENTATION.
                    ip_stop_row     = ip_stop_row
                    ip_stop_column  = ip_stop_column ).
 
+  ENDMETHOD.
+
+
+  METHOD clone.
+    "Constructor regenerates own guid
+    CREATE OBJECT eo_clone
+      EXPORTING
+        ip_dimension_range = me->mv_rule_range.
+    eo_clone->mode_cellis        = me->mode_cellis.
+    eo_clone->mode_textfunction  = me->mode_textfunction.
+    eo_clone->mode_colorscale    = me->mode_colorscale.
+    eo_clone->mode_databar       = me->mode_databar.
+    eo_clone->mode_expression    = me->mode_expression.
+    eo_clone->mode_iconset       = me->mode_iconset.
+    eo_clone->mode_top10         = me->mode_top10.
+    eo_clone->mode_above_average = me->mode_above_average.
+    eo_clone->priority           = me->priority.
+    eo_clone->rule               = me->rule.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_excel_style_cond.clas.abap
+++ b/src/zcl_excel_style_cond.clas.abap
@@ -1,7 +1,8 @@
 CLASS zcl_excel_style_cond DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel_worksheet .
 
   PUBLIC SECTION.
     CLASS zcl_excel_style_conditional DEFINITION LOAD .

--- a/src/zcl_excel_table.clas.abap
+++ b/src/zcl_excel_table.clas.abap
@@ -116,11 +116,14 @@ CLASS zcl_excel_table DEFINITION
         zcx_excel .
 *"* protected components of class ZCL_EXCEL_TABLE
 *"* do not include other source files here!!!
-*"* protected components of class ZCL_EXCEL_TABLE
-*"* do not include other source files here!!!
-*"* protected components of class ZCL_EXCEL_TABLE
-*"* do not include other source files here!!!
   PROTECTED SECTION.
+    "! Returns a deep copy of this table without an id; the caller is
+    "! responsible for assigning the id (via set_id) and adding the clone
+    "! to a worksheet's tables collection.
+    METHODS clone
+      RETURNING
+        VALUE(eo_clone) TYPE REF TO zcl_excel_table .
+
   PRIVATE SECTION.
 
     DATA id TYPE i .
@@ -160,6 +163,19 @@ CLASS zcl_excel_table IMPLEMENTATION.
 
   METHOD get_id.
     ov_id = id.
+  ENDMETHOD.
+
+
+  METHOD clone.
+    CREATE OBJECT eo_clone.
+    eo_clone->fieldcat   = me->fieldcat.
+    eo_clone->settings   = me->settings.
+    eo_clone->name       = me->name.
+    "table_data is a generic data reference - share the reference; cloning the
+    "underlying ABAP internal table generically is rarely desired (table content
+    "lives in cells anyway). Caller may overwrite via set_data when needed.
+    eo_clone->table_data = me->table_data.
+    "Intentionally leave id initial - caller assigns via set_id.
   ENDMETHOD.
 
 

--- a/src/zcl_excel_table.clas.abap
+++ b/src/zcl_excel_table.clas.abap
@@ -1,7 +1,8 @@
 CLASS zcl_excel_table DEFINITION
   PUBLIC
   FINAL
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel_worksheet .
 
 *"* public components of class ZCL_EXCEL_TABLE
 *"* do not include other source files here!!!

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -77,7 +77,7 @@ CLASS zcl_excel_worksheet DEFINITION
     TYPES:
         mty_ts_merge TYPE SORTED TABLE OF mty_merge WITH UNIQUE KEY table_line.
 
-    TYPES:
+        TYPES:
       ty_area TYPE c LENGTH 1 .
 
     "! Flags controlling which "categories" of worksheet contents are NOT copied during a clone

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -80,6 +80,29 @@ CLASS zcl_excel_worksheet DEFINITION
     TYPES:
       ty_area TYPE c LENGTH 1 .
 
+    "! Flags controlling which "categories" of worksheet contents are NOT copied during a clone
+    "! operation - using a default value (initial structure) gives a fulle clone.
+    TYPES:
+      BEGIN OF ts_clone_options,
+        skip_cells              TYPE abap_bool, "! Cell values, formulas, RTF, per-cell styles & cell-table refs
+        skip_column_dimensions  TYPE abap_bool, "! Column widths, visibility, outline level, column-style
+        skip_row_dimensions     TYPE abap_bool, "! Row heights, visibility, outline level, row-style
+        skip_merged_cells       TYPE abap_bool, "! Cell merging information
+        skip_drawings           TYPE abap_bool, "! Images and drawings
+        skip_charts             TYPE abap_bool, "! Charts
+        skip_comments           TYPE abap_bool, "! Comments
+        skip_hyperlinks         TYPE abap_bool, "! Hyperlinks
+        skip_data_validations   TYPE abap_bool, "! Data validation settings
+        skip_conditional_styles TYPE abap_bool, "! Condition styles
+        skip_tables             TYPE abap_bool, "! Tables
+        skip_autofilter         TYPE abap_bool, "! Autofilters
+        skip_named_ranges       TYPE abap_bool, "! Worksheet-local named ranges
+        skip_freeze_panes       TYPE abap_bool, "! Freeze panes + active/top-left cell
+        skip_page_setup         TYPE abap_bool, "! Sheet setup (margins/orientation/...), page breaks, print titles
+        skip_sheet_properties   TYPE abap_bool, "! Tabcolor, gridlines, RTL, zoom, hidden, default style, default formats
+        skip_sheet_protection   TYPE abap_bool, "! Protection flags, password
+      END OF ts_clone_options.
+
     CONSTANTS c_break_column TYPE zexcel_break VALUE 2 ##NO_TEXT.
     CONSTANTS c_break_none TYPE zexcel_break VALUE 0 ##NO_TEXT.
     CONSTANTS c_break_row TYPE zexcel_break VALUE 1 ##NO_TEXT.
@@ -705,6 +728,31 @@ CLASS zcl_excel_worksheet DEFINITION
         !ir_table     TYPE REF TO zcl_excel_table
         !ip_fieldname TYPE zexcel_fieldname
         !ip_header    TYPE abap_bool
+      RAISING
+        zcx_excel .
+
+    "! Populate this (freshly created) worksheet with a deep copy of the
+    "! contents of <em>io_source</em>, which must belong to the same workbook.
+    "!
+    "! The copy is generally "disconnected": subsequent changes on the new worksheet do
+    "! should not affect the source worksheet.
+    "! However, there are exceptions from this rule:
+    "!  - Style GUIDs that live in the workbook-wide  styles collection are intentionally
+    "!    shared - you may follow up with <em>add_new_style</em> to fork a style if independent
+    "!    in edits are required.
+    "!  - Drawings are copied 'by reference'.
+    "!
+    "! You can use the <em>is_options</em> input parameter to skip certain types of artifacts from
+    "! being copied.
+    "!
+    "! @parameter io_source | The source worksheet to copy from.
+    "! @parameter is_options | Skip-flags controlling which categories are copied.
+    "! @raising zcx_excel | If <em>io_source</em> belongs to another workbook or
+    "!                     a structural conflict is detected.
+    METHODS clone_from
+      IMPORTING
+        !io_source  TYPE REF TO zcl_excel_worksheet
+        !is_options TYPE ts_clone_options OPTIONAL
       RAISING
         zcx_excel .
   PRIVATE SECTION.
@@ -2117,6 +2165,325 @@ CLASS zcl_excel_worksheet IMPLEMENTATION.
     upper_cell-cell_column  = 1.
 
   ENDMETHOD.                    "CONSTRUCTOR
+
+
+  METHOD clone_from.
+    " Deep-copy implementation. Order matters:
+    "   1) tables  - cell-level table refs need remapping
+    "   2) cells   - sheet_content + table-ref remap
+    "   3) everything else (independent of cells)
+
+    DATA: lo_iter            TYPE REF TO zcl_excel_collection_iterator,
+          lo_old_column      TYPE REF TO zcl_excel_column,
+          lo_new_column      TYPE REF TO zcl_excel_column,
+          lo_old_row         TYPE REF TO zcl_excel_row,
+          lo_new_row         TYPE REF TO zcl_excel_row,
+          lo_old_table       TYPE REF TO zcl_excel_table,
+          lo_new_table       TYPE REF TO zcl_excel_table,
+          lo_old_drawing     TYPE REF TO zcl_excel_drawing,
+          lo_new_drawing     TYPE REF TO zcl_excel_drawing,
+          lo_old_comment     TYPE REF TO zcl_excel_comment,
+          lo_old_hyperlink   TYPE REF TO zcl_excel_hyperlink,
+          lo_old_dv          TYPE REF TO zcl_excel_data_validation,
+          lo_old_style_cond  TYPE REF TO zcl_excel_style_cond,
+          lo_old_range       TYPE REF TO zcl_excel_range,
+          lo_new_range       TYPE REF TO zcl_excel_range,
+          lo_old_autofilter  TYPE REF TO zcl_excel_autofilter,
+          lo_new_autofilter  TYPE REF TO zcl_excel_autofilter,
+          lv_old_sheet_token TYPE string,
+          lv_new_sheet_token TYPE string,
+          lv_value           TYPE zexcel_range_value,
+          lv_table_id        TYPE i.
+
+    TYPES: BEGIN OF ty_table_map_line,
+             old TYPE REF TO zcl_excel_table,
+             new TYPE REF TO zcl_excel_table,
+           END OF ty_table_map_line.
+    TYPES: ty_table_map TYPE HASHED TABLE OF ty_table_map_line WITH UNIQUE KEY old.
+    DATA: lt_table_map TYPE ty_table_map,
+          ls_table_map TYPE ty_table_map_line.
+
+    FIELD-SYMBOLS: <ls_cell>     LIKE LINE OF me->sheet_content,
+                   <ls_table_map> LIKE LINE OF lt_table_map.
+
+    "--------------------------------------------------------------------
+    " Same-workbook safeguard
+    "--------------------------------------------------------------------
+    IF io_source IS NOT BOUND.
+      zcx_excel=>raise_text( 'Source worksheet not bound' ).
+    ENDIF.
+    IF io_source = me.
+      zcx_excel=>raise_text( 'Source and target worksheet must be different' ).
+    ENDIF.
+    IF io_source->excel <> me->excel.
+      zcx_excel=>raise_text( 'Source worksheet belongs to another workbook' ).
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Sheet properties (interface zif_excel_sheet_properties + simple flags)
+    "--------------------------------------------------------------------
+    IF is_options-skip_sheet_properties = abap_false.
+      me->zif_excel_sheet_properties~hidden                    = io_source->zif_excel_sheet_properties~hidden.
+      me->zif_excel_sheet_properties~show_zeros                = io_source->zif_excel_sheet_properties~show_zeros.
+      me->zif_excel_sheet_properties~style                     = io_source->zif_excel_sheet_properties~style.
+      me->zif_excel_sheet_properties~zoomscale                 = io_source->zif_excel_sheet_properties~zoomscale.
+      me->zif_excel_sheet_properties~zoomscale_normal          = io_source->zif_excel_sheet_properties~zoomscale_normal.
+      me->zif_excel_sheet_properties~zoomscale_pagelayoutview  = io_source->zif_excel_sheet_properties~zoomscale_pagelayoutview.
+      me->zif_excel_sheet_properties~zoomscale_sheetlayoutview = io_source->zif_excel_sheet_properties~zoomscale_sheetlayoutview.
+      me->zif_excel_sheet_properties~summarybelow              = io_source->zif_excel_sheet_properties~summarybelow.
+      me->zif_excel_sheet_properties~summaryright              = io_source->zif_excel_sheet_properties~summaryright.
+      me->zif_excel_sheet_properties~selected                  = io_source->zif_excel_sheet_properties~selected.
+      me->zif_excel_sheet_properties~hide_columns_from         = io_source->zif_excel_sheet_properties~hide_columns_from.
+
+      me->print_gridlines           = io_source->print_gridlines.
+      me->show_gridlines            = io_source->show_gridlines.
+      me->show_rowcolheaders        = io_source->show_rowcolheaders.
+      me->tabcolor                  = io_source->tabcolor.
+      me->right_to_left             = io_source->right_to_left.
+      me->default_excel_date_format = io_source->default_excel_date_format.
+      me->default_excel_time_format = io_source->default_excel_time_format.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Sheet protection (interface zif_excel_sheet_protection)
+    "--------------------------------------------------------------------
+    IF is_options-skip_sheet_protection = abap_false.
+      me->zif_excel_sheet_protection~auto_filter           = io_source->zif_excel_sheet_protection~auto_filter.
+      me->zif_excel_sheet_protection~delete_columns        = io_source->zif_excel_sheet_protection~delete_columns.
+      me->zif_excel_sheet_protection~delete_rows           = io_source->zif_excel_sheet_protection~delete_rows.
+      me->zif_excel_sheet_protection~format_cells          = io_source->zif_excel_sheet_protection~format_cells.
+      me->zif_excel_sheet_protection~format_columns        = io_source->zif_excel_sheet_protection~format_columns.
+      me->zif_excel_sheet_protection~format_rows           = io_source->zif_excel_sheet_protection~format_rows.
+      me->zif_excel_sheet_protection~insert_columns        = io_source->zif_excel_sheet_protection~insert_columns.
+      me->zif_excel_sheet_protection~insert_hyperlinks     = io_source->zif_excel_sheet_protection~insert_hyperlinks.
+      me->zif_excel_sheet_protection~insert_rows           = io_source->zif_excel_sheet_protection~insert_rows.
+      me->zif_excel_sheet_protection~objects               = io_source->zif_excel_sheet_protection~objects.
+      me->zif_excel_sheet_protection~password              = io_source->zif_excel_sheet_protection~password.
+      me->zif_excel_sheet_protection~pivot_tables          = io_source->zif_excel_sheet_protection~pivot_tables.
+      me->zif_excel_sheet_protection~protected             = io_source->zif_excel_sheet_protection~protected.
+      me->zif_excel_sheet_protection~scenarios             = io_source->zif_excel_sheet_protection~scenarios.
+      me->zif_excel_sheet_protection~select_locked_cells   = io_source->zif_excel_sheet_protection~select_locked_cells.
+      me->zif_excel_sheet_protection~select_unlocked_cells = io_source->zif_excel_sheet_protection~select_unlocked_cells.
+      me->zif_excel_sheet_protection~sheet                 = io_source->zif_excel_sheet_protection~sheet.
+      me->zif_excel_sheet_protection~sort                  = io_source->zif_excel_sheet_protection~sort.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Page setup, page breaks, print titles
+    "--------------------------------------------------------------------
+    IF is_options-skip_page_setup = abap_false.
+      IF io_source->sheet_setup IS BOUND.
+        me->sheet_setup = io_source->sheet_setup->clone( ).
+      ENDIF.
+      IF io_source->mo_pagebreaks IS BOUND.
+        me->mo_pagebreaks = io_source->mo_pagebreaks->clone( ).
+      ENDIF.
+      IF io_source->print_title_col_from IS NOT INITIAL.
+        me->zif_excel_sheet_printsettings~set_print_repeat_columns(
+          iv_columns_from = io_source->print_title_col_from
+          iv_columns_to   = io_source->print_title_col_to ).
+      ENDIF.
+      IF io_source->print_title_row_from IS NOT INITIAL.
+        me->zif_excel_sheet_printsettings~set_print_repeat_rows(
+          iv_rows_from = io_source->print_title_row_from
+          iv_rows_to   = io_source->print_title_row_to ).
+      ENDIF.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Freeze panes / active cell / view
+    "--------------------------------------------------------------------
+    IF is_options-skip_freeze_panes = abap_false.
+      IF io_source->freeze_pane_cell_column IS NOT INITIAL OR
+         io_source->freeze_pane_cell_row    IS NOT INITIAL.
+        me->freeze_panes( ip_num_columns = io_source->freeze_pane_cell_column
+                          ip_num_rows    = io_source->freeze_pane_cell_row ).
+      ENDIF.
+      me->pane_top_left_cell      = io_source->pane_top_left_cell.
+      me->sheetview_top_left_cell = io_source->sheetview_top_left_cell.
+      me->active_cell             = io_source->active_cell.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Column dimensions (must include style references too)
+    "--------------------------------------------------------------------
+    IF is_options-skip_column_dimensions = abap_false.
+      lo_iter = io_source->columns->get_iterator( ).
+      WHILE lo_iter->has_next( ) = abap_true.
+        lo_old_column ?= lo_iter->get_next( ).
+        lo_new_column = lo_old_column->clone( io_worksheet = me ).
+        me->columns->add( lo_new_column ).
+      ENDWHILE.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Row dimensions + outlines
+    "--------------------------------------------------------------------
+    IF is_options-skip_row_dimensions = abap_false.
+      lo_iter = io_source->rows->get_iterator( ).
+      WHILE lo_iter->has_next( ) = abap_true.
+        lo_old_row ?= lo_iter->get_next( ).
+        lo_new_row = lo_old_row->clone( ).
+        me->rows->add( lo_new_row ).
+      ENDWHILE.
+      me->mt_row_outlines = io_source->mt_row_outlines.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Tables - clone first so cell-level table refs can be remapped
+    "--------------------------------------------------------------------
+    IF is_options-skip_tables = abap_false.
+      lo_iter = io_source->tables->get_iterator( ).
+      WHILE lo_iter->has_next( ) = abap_true.
+        lo_old_table ?= lo_iter->get_next( ).
+        lo_new_table = lo_old_table->clone( ).
+        lv_table_id = me->excel->get_next_table_id( ).
+        lo_new_table->set_id( iv_id = lv_table_id ).
+        me->tables->add( lo_new_table ).
+        ls_table_map-old = lo_old_table.
+        ls_table_map-new = lo_new_table.
+        INSERT ls_table_map INTO TABLE lt_table_map.
+      ENDWHILE.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Cells (sheet_content). cell_style GUIDs are workbook-scoped and so
+    " are intentionally shared. Cells that referred to a source-table get
+    " remapped to the matching cloned table; if the table was not cloned
+    " (skip_tables) the dangling reference is cleared
+    "--------------------------------------------------------------------
+    IF is_options-skip_cells = abap_false.
+      me->sheet_content     = io_source->sheet_content.
+      me->lower_cell        = io_source->lower_cell.
+      me->upper_cell        = io_source->upper_cell.
+      me->column_formulas   = io_source->column_formulas.
+      me->mt_ignored_errors = io_source->mt_ignored_errors.
+
+      LOOP AT me->sheet_content ASSIGNING <ls_cell> WHERE table IS BOUND.
+        READ TABLE lt_table_map ASSIGNING <ls_table_map> WITH TABLE KEY old = <ls_cell>-table.
+        IF sy-subrc = 0.
+          <ls_cell>-table = <ls_table_map>-new.
+        ELSE.
+          CLEAR: <ls_cell>-table,
+                 <ls_cell>-table_fieldname,
+                 <ls_cell>-table_header.
+        ENDIF.
+      ENDLOOP.
+    ENDIF.
+
+    "-------------------------------------------------------------------
+    " Merged cells
+    "--------------------------------------------------------------------
+    IF is_options-skip_merged_cells = abap_false.
+      me->mt_merged_cells = io_source->mt_merged_cells.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Drawings (images)
+    "--------------------------------------------------------------------
+    IF is_options-skip_drawings = abap_false.
+      lo_iter = io_source->drawings->get_iterator( ).
+      WHILE lo_iter->has_next( ) = abap_true.
+        lo_old_drawing ?= lo_iter->get_next( ).
+        lo_new_drawing = lo_old_drawing->clone( ).
+        me->drawings->add( lo_new_drawing ).
+      ENDWHILE.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Charts
+    "--------------------------------------------------------------------
+    IF is_options-skip_charts = abap_false.
+      lo_iter = io_source->charts->get_iterator( ).
+      WHILE lo_iter->has_next( ) = abap_true.
+        lo_old_drawing ?= lo_iter->get_next( ).
+        lo_new_drawing = lo_old_drawing->clone( ).
+        me->charts->add( lo_new_drawing ).
+      ENDWHILE.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Comments
+    "--------------------------------------------------------------------
+    IF is_options-skip_comments = abap_false.
+      lo_iter = io_source->comments->get_iterator( ).
+      WHILE lo_iter->has_next( ) = abap_true.
+        lo_old_comment ?= lo_iter->get_next( ).
+        me->comments->add( lo_old_comment->clone( ) ).
+      ENDWHILE.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Hyperlinks - cell coordinates are unchanged so the cloned hyperlink
+    " targets the same cell on the new worksheet.
+    "--------------------------------------------------------------------
+    IF is_options-skip_hyperlinks = abap_false.
+      lo_iter = io_source->hyperlinks->get_iterator( ).
+      WHILE lo_iter->has_next( ) = abap_true.
+        lo_old_hyperlink ?= lo_iter->get_next( ).
+        me->hyperlinks->add( lo_old_hyperlink->clone( ) ).
+      ENDWHILE.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Data validations
+    "--------------------------------------------------------------------
+    IF is_options-skip_data_validations = abap_false.
+      lo_iter = io_source->data_validations->get_iterator( ).
+      WHILE lo_iter->has_next( ) = abap_true.
+        lo_old_dv ?= lo_iter->get_next( ).
+        me->data_validations->add( lo_old_dv->clone( ) ).
+      ENDWHILE.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Conditional formatting rules
+    "--------------------------------------------------------------------
+    IF is_options-skip_conditional_styles = abap_false.
+      lo_iter = io_source->styles_cond->get_iterator( ).
+      WHILE lo_iter->has_next( ) = abap_true.
+        lo_old_style_cond ?= lo_iter->get_next( ).
+        me->styles_cond->add( lo_old_style_cond->clone( ) ).
+      ENDWHILE.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Worksheet-local named ranges. Patch the embedded sheet name (if any)
+    " so the cloned range points at this worksheet rather than the source.
+    " The implicit print-titles range is skipped here because it was already
+    " recreated in the page-setup branch above (when not skipped there).
+    "--------------------------------------------------------------------
+    IF is_options-skip_named_ranges = abap_false.
+      lv_old_sheet_token = zcl_excel_common=>escape_string( io_source->get_title( ) ) && '!'.
+      lv_new_sheet_token = zcl_excel_common=>escape_string( me->get_title( ) )         && '!'.
+      lo_iter = io_source->ranges->get_iterator( ).
+      WHILE lo_iter->has_next( ) = abap_true.
+        lo_old_range ?= lo_iter->get_next( ).
+        IF lo_old_range->name = zif_excel_sheet_printsettings=>gcv_print_title_name AND
+           is_options-skip_page_setup = abap_false.
+          CONTINUE.
+        ENDIF.
+        lo_new_range = lo_old_range->clone( ).
+        lv_value     = lo_new_range->get_value( ).
+        REPLACE ALL OCCURRENCES OF lv_old_sheet_token IN lv_value WITH lv_new_sheet_token.
+        lo_new_range->set_range_value( lv_value ).
+        me->ranges->add( lo_new_range ).
+      ENDWHILE.
+    ENDIF.
+
+    "--------------------------------------------------------------------
+    " Autofilter (lives on the workbook, keyed by worksheet).
+    "--------------------------------------------------------------------
+    IF is_options-skip_autofilter = abap_false.
+      lo_old_autofilter = me->excel->get_autofilters_reference( )->get( io_source ).
+      IF lo_old_autofilter IS BOUND.
+        lo_new_autofilter = lo_old_autofilter->clone( io_sheet = me ).
+        me->excel->get_autofilters_reference( )->add_existing(
+          io_autofilter = lo_new_autofilter ).
+      ENDIF.
+    ENDIF.
+
+  ENDMETHOD.
 
 
   METHOD convert_to_table.

--- a/src/zcl_excel_worksheet.clas.abap
+++ b/src/zcl_excel_worksheet.clas.abap
@@ -1,6 +1,7 @@
 CLASS zcl_excel_worksheet DEFINITION
   PUBLIC
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel.
 
   PUBLIC SECTION.
 *"* public components of class ZCL_EXCEL_WORKSHEET

--- a/src/zcl_excel_worksheet_pagebreaks.clas.abap
+++ b/src/zcl_excel_worksheet_pagebreaks.clas.abap
@@ -23,6 +23,10 @@ CLASS zcl_excel_worksheet_pagebreaks DEFINITION
       RETURNING
         VALUE(rt_pagebreaks) TYPE tt_pagebreak_at .
   PROTECTED SECTION.
+    "! Returns a deep copy of this page-break collection.
+    METHODS clone
+      RETURNING
+        VALUE(eo_clone) TYPE REF TO zcl_excel_worksheet_pagebreaks .
 
     DATA mt_pagebreaks TYPE tt_pagebreak_at .
   PRIVATE SECTION.
@@ -47,5 +51,11 @@ CLASS zcl_excel_worksheet_pagebreaks IMPLEMENTATION.
 
   METHOD get_all_pagebreaks.
     rt_pagebreaks = me->mt_pagebreaks.
+  ENDMETHOD.
+
+
+  METHOD clone.
+    CREATE OBJECT eo_clone.
+    eo_clone->mt_pagebreaks = me->mt_pagebreaks.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_excel_worksheet_pagebreaks.clas.abap
+++ b/src/zcl_excel_worksheet_pagebreaks.clas.abap
@@ -1,6 +1,7 @@
 CLASS zcl_excel_worksheet_pagebreaks DEFINITION
   PUBLIC
-  CREATE PUBLIC .
+  CREATE PUBLIC
+  GLOBAL FRIENDS zcl_excel_worksheet .
 
   PUBLIC SECTION.
 


### PR DESCRIPTION
Adding method zcl_excel->clone_worksheet that allowes to add a new worksheet by copying the content of an existing worksheet.
(Original issue #1004  )

Corresponding demo case is submitted in [PR 98](https://github.com/abap2xlsx/demos/pull/98) of the [demos](https://github.com/abap2xlsx/demos) repository.

Note that this is a first draft implementation. While in general the aim is to copy 'everything' on the sheet - including charts, comments etc., my primary focus in the first place is to make sure basic things (cell content, formulas, styling, column and row sizes) work well. More 'exotic' content might fail, so contributions and feedback are highly welcome.

